### PR TITLE
ISR Triggerscript

### DIFF
--- a/tcl_scripts/vivado_Trigger_ISR_via_VIO.tcl
+++ b/tcl_scripts/vivado_Trigger_ISR_via_VIO.tcl
@@ -1,0 +1,32 @@
+#******************************************************************************
+# Copyright 2021 Robert Zipprich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+#******************************************************************************
+
+# Script to Trigger the ISR of the Ultrazohm once 
+
+# Change to working-directory
+# set work_directory [get_property DIRECTORY [current_project]] ; 
+# cd $work_directory ; 
+
+puts "Trigger ISR once";
+
+#Set Interrupt-IO to high
+set_property OUTPUT_VALUE 1 [get_hw_probes zusys_i/Interrupt/vio_0_probe_out0 -of_objects [get_hw_vios -of_objects [get_hw_devices xczu9_0] -filter {CELL_NAME=~"zusys_i/Interrupt/vio_interrupt"}]];
+commit_hw_vio [get_hw_probes {zusys_i/Interrupt/vio_0_probe_out0} -of_objects [get_hw_vios -of_objects [get_hw_devices xczu9_0] -filter {CELL_NAME=~"zusys_i/Interrupt/vio_interrupt"}]];
+
+#Set Interrupt-IO to low
+set_property OUTPUT_VALUE 0 [get_hw_probes zusys_i/Interrupt/vio_0_probe_out0 -of_objects [get_hw_vios -of_objects [get_hw_devices xczu9_0] -filter {CELL_NAME=~"zusys_i/Interrupt/vio_interrupt"}]];
+commit_hw_vio [get_hw_probes {zusys_i/Interrupt/vio_0_probe_out0} -of_objects [get_hw_vios -of_objects [get_hw_devices xczu9_0] -filter {CELL_NAME=~"zusys_i/Interrupt/vio_interrupt"}]];
+
+puts "Trigger done!";


### PR DESCRIPTION
**Migrated from Bitbucket**
- Original Author: **Robert Zipprich** *(no GitHub account)*
- Original Created: March 11, 2022 at 08:15 AM UTC
- Original URL: https://bitbucket.org/ultrazohm/ultrazohm_sw/pull-requests/270

---

#### Summary: What kind of change does this PR introduce?

* Introducing a new Script to Trigger the ISR through the VIO located in the “Interrupt”-hierarchie

#### What is the current behavior?

* no Script available

#### What is the new behavior?

* Script available
* Possibility to add a button/custom-command to vivado for easier ISR-Debugging

#### Does this PR introduce a breaking change?

* no

#### Which tests have to be done by reviewers before approving?

* should be used with the UZ-standard-Software
* change the Interrupt-source to the VIO \(Interrupt-source 7\)

    * This could be a little bit tricky since this isn’t a default-case covered with the uz\_global\_configuration.h. You need to hard-code the Triggersource in the driver for the AXI-interrupt-mux. Find the Line “uz\_mux\_axi\_set\_mux\(self, self->config.mux\);“ in the “uz\_mux\_axi.c“ and change it to “uz\_mux\_axi\_set\_mux\(self, 7\);” Although don’t forget to modify the assertion to prevend error-states!
    
* Interrupt-style must be “rising-edge“
* integrate the script the same way the export\_xsa\_script is integrated \(custom command\)
* fire some interrupts and observe the system behavior through vitis in debug-view

#### Other information:

* Issue to discuss: issue #220

#### Please check if the PR fulfills these requirements

* Build pipelines pass
* Tests for the changes have been defined
* Docs have been added/updated

‌
