### PR TITLE
Feature/fix Trajectorie tests Issue320

### DIFF
--- a/vitis/software/Baremetal/src/uz/uz_Trajectory/uz_Trajectory.c
+++ b/vitis/software/Baremetal/src/uz/uz_Trajectory/uz_Trajectory.c
@@ -27,6 +27,7 @@ typedef struct uz_Trajectory_t {
 	bool is_ready;
 	struct uz_Trajectory_config config;
 	bool is_running;
+	bool is_running_latch;
 	bool is_finished;
 	uint32_t Trajectory_Counter;
 	uint32_t Step_Counter;
@@ -69,6 +70,7 @@ uz_Trajectory_t* uz_Trajectory_init(struct uz_Trajectory_config config){
 
 	self->config = config;
     self->is_running = false;
+	self->is_running_latch = false;
     self->Trajectory_Counter = 0U;
     self->Step_Counter = 0U;
     self->Repeats_Counter = 0U;
@@ -94,6 +96,7 @@ void uz_Trajectory_Start(uz_Trajectory_t* self){
     uz_assert(self->is_ready);
     if(self->is_finished == false){
     	self->is_running = true;
+		self->is_running_latch = true;
     }
 }
 
@@ -108,6 +111,7 @@ void uz_Trajectory_Reset(uz_Trajectory_t* self){
     uz_assert(self->is_ready);
     self->is_running = false;
     self->is_finished = false;
+	self->is_running_latch = false;
     self->Trajectory_Counter = 0U;
     self->Step_Counter = 0U;
     self->Repeats_Counter = 0U;
@@ -118,11 +122,50 @@ float uz_Trajectory_Step(uz_Trajectory_t* self){
     uz_assert(self->is_ready);
     float Temp_Trajectory_out = 0.0f;
 
-    // Check if Trajectory is Running
-	if(self->is_running == true && self->is_finished == false){
+	// Check is the start-function is called
+	if(self->is_running_latch == true){
+		// Check if Trajectory is Running
+		if(self->is_running == true && self->is_finished == false){
+			if(self->config.RepeatStyle == Repeat_Times){
+				if(self->Repeats_Counter < self->config.Repeats){
+					if(self->Step_Counter < self->config.Number_Sample_Points){
+						// Choose Interpolation-Style
+						switch(self->config.selection_interpolation){
+						case Zero_Order_Hold:
+							// Use Indicies
+							Temp_Trajectory_out = self->config.Sample_Amplitude_Y[self->Step_Counter];
+							break;
+						case Linear:
+							// Calculate linear equation
+							Temp_Trajectory_out = (self->Interpolation_Coefficients[1][self->Step_Counter] * (float)self->Trajectory_Counter + self->config.Sample_Amplitude_Y[self->Step_Counter]);
+							break;
+						default:
+							// Trigger an Assertion- this code should never be reached
+							uz_assert(true);
+							break;
+						}
+						// Increase Trajectory-Counter
+						self->Trajectory_Counter++;
+						// Calculate actual Step
+						if(self->Trajectory_Counter >= get_TimeBase(self, self->Step_Counter)){
+							// Increase-Step-Counter
+							self->Step_Counter++;
+							self->Trajectory_Counter = 0U;
+						}
+					}else{
+						self->Repeats_Counter++;
+						self->Step_Counter = 0U;
+					}
+				}else{
+					//finished running
+					self->is_running = false;
+					self->is_finished = true;
+					self->is_running_latch = false;
+				}
 
-		if(self->config.RepeatStyle == Repeat_Times){
-			if(self->Repeats_Counter < self->config.Repeats){
+
+			}else if(self->config.RepeatStyle == Repeat_Inf){
+
 				if(self->Step_Counter < self->config.Number_Sample_Points){
 					// Choose Interpolation-Style
 					switch(self->config.selection_interpolation){
@@ -148,76 +191,42 @@ float uz_Trajectory_Step(uz_Trajectory_t* self){
 						self->Trajectory_Counter = 0U;
 					}
 				}else{
-					self->Repeats_Counter++;
 					self->Step_Counter = 0U;
 				}
-			}else{
-				//finished running
-				self->is_running = false;
-				self->is_finished = true;
 			}
 
+		}else{ // Trajectory not running
 
-		}else if(self->config.RepeatStyle == Repeat_Inf){
-
-			if(self->Step_Counter < self->config.Number_Sample_Points){
-				// Choose Interpolation-Style
-				switch(self->config.selection_interpolation){
-				case Zero_Order_Hold:
-					// Use Indicies
-					Temp_Trajectory_out = self->config.Sample_Amplitude_Y[self->Step_Counter];
+			switch(self->config.StopStyle){
+				case ForceToZero:
+					Temp_Trajectory_out = 0.0f;
 					break;
-				case Linear:
-					// Calculate linear equation
-					Temp_Trajectory_out = (self->Interpolation_Coefficients[1][self->Step_Counter] * (float)self->Trajectory_Counter + self->config.Sample_Amplitude_Y[self->Step_Counter]);
+				case HoldLast:
+					switch(self->config.selection_interpolation){
+						case Zero_Order_Hold:
+							// Use Indicies
+							Temp_Trajectory_out = self->config.Sample_Amplitude_Y[self->Step_Counter];
+							break;
+						case Linear:
+							// Calculate linear equation
+							Temp_Trajectory_out = (self->Interpolation_Coefficients[1][self->Step_Counter] * (float)self->Trajectory_Counter + self->config.Sample_Amplitude_Y[self->Step_Counter]);
+							break;
+						default:
+							// Trigger an Assertion- this code should never be reached
+							uz_assert(true);
+							break;
+						}
 					break;
 				default:
 					// Trigger an Assertion- this code should never be reached
 					uz_assert(true);
+					Temp_Trajectory_out = 0.0f;
 					break;
-				}
-				// Increase Trajectory-Counter
-				self->Trajectory_Counter++;
-				// Calculate actual Step
-				if(self->Trajectory_Counter >= get_TimeBase(self, self->Step_Counter)){
-					// Increase-Step-Counter
-					self->Step_Counter++;
-					self->Trajectory_Counter = 0U;
-				}
-			}else{
-				self->Step_Counter = 0U;
 			}
+
 		}
-
-	}else{ // Trajectory not running
-
-		switch(self->config.StopStyle){
-			case ForceToZero:
-				Temp_Trajectory_out = 0.0f;
-				break;
-			case HoldLast:
-				switch(self->config.selection_interpolation){
-					case Zero_Order_Hold:
-						// Use Indicies
-						Temp_Trajectory_out = self->config.Sample_Amplitude_Y[self->Step_Counter];
-						break;
-					case Linear:
-						// Calculate linear equation
-						Temp_Trajectory_out = (self->Interpolation_Coefficients[1][self->Step_Counter] * (float)self->Trajectory_Counter + self->config.Sample_Amplitude_Y[self->Step_Counter]);
-						break;
-					default:
-						// Trigger an Assertion- this code should never be reached
-						uz_assert(true);
-						break;
-					}
-				break;
-			default:
-				// Trigger an Assertion- this code should never be reached
-				uz_assert(true);
-				Temp_Trajectory_out = 0.0f;
-				break;
-		}
-
+	}else{
+		Temp_Trajectory_out = 0.0f;
 	}
 	return Temp_Trajectory_out;
 }

--- a/vitis/software/Baremetal/src/uz/uz_Trajectory/uz_Trajectory.h
+++ b/vitis/software/Baremetal/src/uz/uz_Trajectory/uz_Trajectory.h
@@ -7,7 +7,7 @@
  * @brief Maximum number of samples that can be stored. Should be as small as possible to save resources.
  * 
  */
-#define MAX_TRAJECTORY_SAMPLES 	20U
+#define MAX_TRAJECTORY_SAMPLES 	50U
 
 /*! enum for readable configuration of the interpolation type */
 enum uz_Trajectory_interpolation_selection {

--- a/vitis/software/Baremetal/test/uz/uz_Trajectory/test_uz_Trajectory.c
+++ b/vitis/software/Baremetal/test/uz/uz_Trajectory/test_uz_Trajectory.c
@@ -1,57 +1,43 @@
 #ifdef TEST
 
 #include "unity.h"
+#include <stdlib.h>
+#include <time.h>
 
 #include "uz_Trajectory.h"
 #include "test_assert_with_exception.h"
 
 struct uz_Trajectory_config config = {0};
+float reference_Values_Amplitude[MAX_TRAJECTORY_SAMPLES];
+float reference_Values_Duration[MAX_TRAJECTORY_SAMPLES];
+
+
 void setUp(void){
+
+	// create Random Trajektorie
+	// Seed rand
+	srand((unsigned int)time(NULL));
+	rand();
+	for(uint32_t i = 0; i < MAX_TRAJECTORY_SAMPLES;i++){
+		//create random  number for Amplitude between -50 and 50
+		int32_t AmpValue 	= ((int32_t)rand() % 100) - 50;
+		reference_Values_Amplitude[i] =  (float)AmpValue;
+		// set length to 5 ISR-Ticks
+		reference_Values_Duration[i] =  5.0f;
+	}
+
     config.selection_interpolation = Linear;
     config.selection_XAxis = ISR_Ticks;
     config.StopStyle = HoldLast;
 	config.RepeatStyle = Repeat_Times;
     config.Number_Sample_Points = MAX_TRAJECTORY_SAMPLES;
-    config.Sample_Amplitude_Y[0]  = 0.0f;
-	config.Sample_Amplitude_Y[1]  = 4.0f;
-	config.Sample_Amplitude_Y[2]  = 6.0f;
-	config.Sample_Amplitude_Y[3]  = 7.0f;
-	config.Sample_Amplitude_Y[4]  = 7.5f;
-	config.Sample_Amplitude_Y[5]  = 9.0f;
-	config.Sample_Amplitude_Y[6]  = 20.0f;
-	config.Sample_Amplitude_Y[7]  = 20.0f;
-	config.Sample_Amplitude_Y[8]  = -20.0f;
-	config.Sample_Amplitude_Y[9]  = 20.0f;
-	config.Sample_Amplitude_Y[10] = 20.0f;
-	config.Sample_Amplitude_Y[11] = 0.0f;
-	config.Sample_Amplitude_Y[12] = 4.0f;
-	config.Sample_Amplitude_Y[13] = 6.0f;
-	config.Sample_Amplitude_Y[14] = 7.0f;
-	config.Sample_Amplitude_Y[15] = 7.5f;
-	config.Sample_Amplitude_Y[16] = 9.0f;
-	config.Sample_Amplitude_Y[17] = 20.0f;
-	config.Sample_Amplitude_Y[18] = 20.0f;
-	config.Sample_Amplitude_Y[19] = 0.0f;
-	config.Sample_Duration_X[0]  = 5.0f;
-	config.Sample_Duration_X[1]  = 5.0f;
-	config.Sample_Duration_X[2]  = 5.0f;
-	config.Sample_Duration_X[3]  = 5.0f;
-	config.Sample_Duration_X[4]  = 5.0f;
-	config.Sample_Duration_X[5]  = 5.0f;
-	config.Sample_Duration_X[6]  = 5.0f;
-	config.Sample_Duration_X[7]  = 5.0f;
-	config.Sample_Duration_X[8]  = 5.0f;
-	config.Sample_Duration_X[9]  = 5.0f;
-	config.Sample_Duration_X[10] = 5.0f;
-	config.Sample_Duration_X[11] = 5.0f;
-	config.Sample_Duration_X[12] = 5.0f;
-	config.Sample_Duration_X[13] = 5.0f;
-	config.Sample_Duration_X[14] = 5.0f;
-	config.Sample_Duration_X[15] = 5.0f;
-	config.Sample_Duration_X[16] = 5.0f;
-	config.Sample_Duration_X[17] = 5.0f;
-	config.Sample_Duration_X[18] = 5.0f;
-	config.Sample_Duration_X[19] = 5.0f;
+
+	// configure Trajectory
+	for(uint32_t i = 0; i < MAX_TRAJECTORY_SAMPLES;i++){
+		config.Sample_Amplitude_Y[i] = reference_Values_Amplitude[i];
+		config.Sample_Duration_X[i] = reference_Values_Duration[i];
+	}
+
 	config.Repeats = 2U;
     config.Stepwidth_ISR = (1.0f / 10000.0f)*(1.0f);
 }
@@ -143,7 +129,6 @@ void test_uz_Trajectory_Step_Calls_ZeroOrderHold(void){
 	// Create Instance
     uz_Trajectory_t* MUT = uz_Trajectory_init(config);
 
-	float reference_Values_Amplitude[MAX_TRAJECTORY_SAMPLES] = {0.0f,4.0f,6.0f,7.0f,7.5f,9.0f,20.0f,20.0f,-20.0f,20.0f,20.0f,0.0f,4.0f,6.0f,7.0f,7.5f,9.0f,20.0f,20.0f,0.0f};
 	uint32_t samplecounter = 0U;
 	float Traj_1_output	= 0.0f;
 
@@ -165,8 +150,6 @@ void test_uz_Trajectory_Step_Calls_LinearInterpolation(void){
 	// Create Instance
     uz_Trajectory_t* MUT = uz_Trajectory_init(config);
 
-	float reference_Values_Amplitude[MAX_TRAJECTORY_SAMPLES] = {0.0f,4.0f,6.0f,7.0f,7.5f,9.0f,20.0f,20.0f,-20.0f,20.0f,20.0f,0.0f,4.0f,6.0f,7.0f,7.5f,9.0f,20.0f,20.0f,0.0f};
-	float reference_Values_Duration[MAX_TRAJECTORY_SAMPLES] = {5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f};
 	uint32_t samplecounter = 0U;
 	uint32_t trajcounter = 0U;
 	float Traj_1_output	= 0.0f;
@@ -203,8 +186,7 @@ void test_uz_Trajectory_StartStopStart_with_Hold(void){
 	// Create Instance
     uz_Trajectory_t* MUT = uz_Trajectory_init(config);
 
-	float reference_Values_Amplitude[MAX_TRAJECTORY_SAMPLES] = {0.0f,4.0f,6.0f,7.0f,7.5f,9.0f,20.0f,20.0f,-20.0f,20.0f,20.0f,0.0f,4.0f,6.0f,7.0f,7.5f,9.0f,20.0f,20.0f,0.0f};
-	float reference_Values_Duration[MAX_TRAJECTORY_SAMPLES] = {5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f};
+
 	float Traj_1_output	= 0.0f;
 	float Ref_Traj	= 0.0f;
 
@@ -262,8 +244,6 @@ void test_uz_Trajectory_StartStopStart_with_ForceToZero(void){
 	config.StopStyle = ForceToZero;
     uz_Trajectory_t* MUT = uz_Trajectory_init(config);
 
-	float reference_Values_Amplitude[MAX_TRAJECTORY_SAMPLES] = {0.0f,4.0f,6.0f,7.0f,7.5f,9.0f,20.0f,20.0f,-20.0f,20.0f,20.0f,0.0f,4.0f,6.0f,7.0f,7.5f,9.0f,20.0f,20.0f,0.0f};
-	float reference_Values_Duration[MAX_TRAJECTORY_SAMPLES] = {5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f};
 	float Traj_1_output	= 0.0f;
 	float Ref_Traj	= 0.0f;
 
@@ -319,8 +299,6 @@ void test_uz_Trajectory_Reset_Trajectory(void){
 	// Create Instance
     uz_Trajectory_t* MUT = uz_Trajectory_init(config);
 
-	float reference_Values_Amplitude[MAX_TRAJECTORY_SAMPLES] = {0.0f,4.0f,6.0f,7.0f,7.5f,9.0f,20.0f,20.0f,-20.0f,20.0f,20.0f,0.0f,4.0f,6.0f,7.0f,7.5f,9.0f,20.0f,20.0f,0.0f};
-	float reference_Values_Duration[MAX_TRAJECTORY_SAMPLES] = {5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f,5.0f};
 	uint32_t samplecounter = 0U;
 	uint32_t trajcounter = 0U;
 	float Traj_1_output	= 0.0f;


### PR DESCRIPTION
**Migrated from Bitbucket**
- Original Author: **Robert Zipprich** *(no GitHub account)*
- Original Created: August 19, 2024 at 09:36 AM UTC
- Original URL: https://bitbucket.org/ultrazohm/ultrazohm_sw/pull-requests/469

---

#### Summary: What kind of change does this PR introduce?

Fix for Ticket #320

#### What is the current behavior?

Tests will fail if #define MAX\_TRAJECTORY\_SAMPLES is adjusted / != 20U

[https://github.com/ultrazohm/ultrazohm_sw/issues/320](https://github.com/ultrazohm/ultrazohm_sw/issues/320){: data-inline-card='' } 

#### What is the new behavior?

coupled the .h-defines with the tests so if the #define MAX\_TRAJECTORY\_SAMPLES changes, the tests will adapt to the new amount of samples

the tests will generate a random reference-trajectory

#### Does this PR introduce a breaking change?

no

#### Which tests have to be done by reviewers before approving?

Adjust the #define MAX\_TRAJECTORY\_SAMPLES and check if the module and tests work as expected 

#### Other information:

no

#### Please check if the PR fulfills these requirements

* Build pipelines pass                                   - passed
* Tests for the changes have been defined   - done
* Docs have been added/updated                - not neccessary

‌
