### PR TITLE
unused PL pins from PULLNONE -> PULLDOWN

### DIFF
--- a/vivado/constraints/te0808/_i_bitgen.xdc
+++ b/vivado/constraints/te0808/_i_bitgen.xdc
@@ -9,5 +9,5 @@ set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
 # Set unused pin pull direction: PULLNONE, PULLUP, PULLDOWN
 #
 
-set_property BITSTREAM.CONFIG.UNUSEDPIN PULLNONE [current_design]
+set_property BITSTREAM.CONFIG.UNUSEDPIN PULLDOWN [current_design]
 


### PR DESCRIPTION
**Migrated from Bitbucket**
- Original Author: @eykeyke
- Original Created: January 23, 2026 at 08:23 AM UTC
- Original URL: https://bitbucket.org/ultrazohm/ultrazohm_sw/pull-requests/540

---

#### Summary: What kind of change does this PR introduce?

* motivation: unused pins are floating, which can lead to undefined behavior on the D-Slots when the CPLD pins are configured as “outputs”, i.e., PL->Adaptercard
* unused PL pins from `PULLNONE` -> `PULLDOWN`
* adds a weak pulldown on all pins not used in the Vivado Design
* from UG908[https://docs.amd.com/r/en-US/ug908-vivado-programming-debugging/Zynq-UltraScale-MPSoC-Bitstream-Settings](https://docs.amd.com/r/en-US/ug908-vivado-programming-debugging/Zynq-UltraScale-MPSoC-Bitstream-Settings){: data-inline-card='' }  

* Pull-Down Strength from DS925 [https://docs.amd.com/r/en-US/ds925-zynq-ultrascale-plus/DC-Characteristics-Over-Recommended-Operating-Conditions](https://docs.amd.com/r/en-US/ds925-zynq-ultrascale-plus/DC-Characteristics-Over-Recommended-Operating-Conditions){: data-inline-card='' }  

* at 1.8V this translates to a pulldown of 15 kΩ to 62 kΩ equivalent

#### What is the current behavior?

* copied from Trenz project this line 
* `set_property BITSTREAM.CONFIG.UNUSEDPIN PULLNONE [current_design]`

#### What is the new behavior?

* PULLDOWN on all unused pins

#### Does this PR introduce a breaking change?

* not sure, to be discussed

#### Which tests have to be done by reviewers before approving?

* not sure, to be discussed

#### Other information:

* 

#### Please check if the PR fulfills these requirements

* Build pipelines pass
* Tests for the changes have been defined
* Docs have been added/updated

‌
