### PR TITLE
Feature/improve gain scheduling

### DIFF
--- a/docs/source/software/control/CurrentControl/CurrentControl.rst
+++ b/docs/source/software/control/CurrentControl/CurrentControl.rst
@@ -103,7 +103,9 @@ Example
         .config_PMSM = config_PMSM,
         .config_id = config_id,
         .config_iq = config_iq,
-        .max_modulation_index = 1.0f / sqrtf(3.0f)
+        .max_modulation_index = 1.0f / sqrtf(3.0f),
+        .Kp_d_limit = 20.0f; //only necessary if Kp_adjustment_flag is set to true
+        .Kp_q_limit = 20.0f; //only necessary if Kp_adjustment_flag is set to true
      };
   }
 

--- a/docs/source/software/control/CurrentControl/uz_CurrentControl_adjust_Kp.rst
+++ b/docs/source/software/control/CurrentControl/uz_CurrentControl_adjust_Kp.rst
@@ -15,7 +15,9 @@ Example
 
   int main(void) {
     struct uz_CurrentControl_config config = {
-    config_iq.samplingTime_sec = 0.00001f
+    .config_iq.samplingTime_sec = 0.00001f
+    .Kp_d_limit = 20.0f;
+    .Kp_q_limit = 20.0f;
     };  //only this parameter is needed
     uz_CurrentControl_t* instance = uz_CurrentControl_init(config);
     struct uz_3ph_dq_t i_actual_Ampere = {.d = 0.8f, .q = 0.8f, .zero = 0.0f};
@@ -35,17 +37,23 @@ It has to be used in conjunction with :ref:`uz_CurrentControl_set_flux_approx`.
 
 .. math::
 
-    \overline{L}_{dd} = \frac{\psi_{d}(i_{d}^*,i_{q})-\psi_{d}(i_{d},i_{q})}{i_{d}^*-i_{d}} \\
-    \overline{L}_{qq} = \frac{\psi_{q}(i_{d},i_{q}^*)-\psi_{q}(i_{d},i_{q})}{i_{q}^*-i_{q}}
+    \hat{L}_{dd} = \frac{\psi_{d}(i_{d}^*,i_{q})-\psi_{d}(i_{d},i_{q})}{i_{d}^*-i_{d}} \\
+    \hat{L}_{qq} = \frac{\psi_{q}(i_{d},i_{q}^*)-\psi_{q}(i_{d},i_{q})}{i_{q}^*-i_{q}}
+
+To prevent numerical instability, the previous value for :math:`\hat{L}_{dd}` and :math:`\hat{L}_{qq}` is used for further calculations, if the absolute error between the reference and actual current is less than 0.001.
 
 Then the new Kp parameters can be calculated:
 
 .. math::
 
-    K_{p,d} = \frac{\overline{L}_{dd}}{2\tau_\sigma}  \qquad \qquad \qquad K_{p,q} = \frac{\overline{L}{qq}}{2\tau_\sigma}
+    K_{p,d} = \frac{\hat{L}_{dd}}{2\tau_\sigma}  \qquad \qquad \qquad K_{p,q} = \frac{\hat{L}{qq}}{2\tau_\sigma}
 
 If the flag ``Kp_adjustment_flag`` is set to true in the ``uz_CurrentControl_config``, the calculated :math:`K_{p,d}` and :math:`K_{p,q}` are automatically written to the pi controllers.
 If false, no adjustment of :math:`K_{p,d}` and :math:`K_{p,q}` is done. 
+The config parameters ``Kp_d_limit`` and ``Kp_q_limit`` can be used to set a limit to the maximum allowed values of the adjusted Kp parameters.
+E.g. set the values to 2x the Kp value calculated with linear :math:`L_{d}` and :math:`L_{q}`.
+If the flag ``Kp_adjustment_flag`` is set to true, ``Kp_d_limit`` and ``Kp_q_limit`` must be larger than 0.
+
 
 .. [#Schroeder_Regelung] Elektrische Antriebe - Regelung von Antriebssystemen, Dierk Schröder, Joachim Böcker, Springer, 2021, 5. Edition (German)
 .. [#Gemassmer_Diss] Effiziente und dynamische Drehmomenteinprägung in hoch ausgenutzten Synchronmaschinen mit eingebetteten Magneten, Tobias Gemaßmer, KIT Scientific Publishing, ISBN: 978-3-7315-0366-8

--- a/vitis/software/Baremetal/src/uz/uz_CurrentControl/uz_CurrentControl.c
+++ b/vitis/software/Baremetal/src/uz/uz_CurrentControl/uz_CurrentControl.c
@@ -72,6 +72,10 @@ uz_CurrentControl_t* uz_CurrentControl_init(struct uz_CurrentControl_config conf
 	config.config_iq.upper_limit = INFINITY;
 	config.config_iq.lower_limit = -INFINITY;
 	uz_assert(config.max_modulation_index > 0.0f);
+	if(config.Kp_adjustment_flag) {
+		uz_assert(config.Kp_d_limit > 0.0f);
+		uz_assert(config.Kp_q_limit > 0.0f);
+	}
 	self->Controller_id = uz_PI_Controller_init(config.config_id);
 	self->Controller_iq = uz_PI_Controller_init(config.config_iq);
 	self->config = config;
@@ -126,21 +130,25 @@ void uz_CurrentControl_set_flux_approx(uz_CurrentControl_t* self, uz_3ph_dq_t fl
 void uz_CurrentControl_adjust_Kp(uz_CurrentControl_t* self, uz_3ph_dq_t i_reference_Ampere,  uz_3ph_dq_t i_actual_Ampere, float BO_factor){
 	uz_assert_not_NULL(self);
 	uz_assert(self->is_ready);
-	uz_3ph_dq_t kp_adjusted = {0};
 	uz_3ph_dq_t current_error = {0};
-	current_error.d = i_reference_Ampere.d - i_actual_Ampere.d;
-	  if (current_error.d == 0.0f) {
-    	current_error.d = 1.1920929E-7f;
-  		}
-	current_error.q = i_reference_Ampere.q - i_actual_Ampere.q ;
-	  if (current_error.q == 0.0f) {
-    	current_error.q = 1.1920929E-7f;
-  		}
-	kp_adjusted.d = ((self->flux_approx_reference.d - self->flux_approx_real.d)/current_error.d) / (BO_factor * self->config.config_id.samplingTime_sec * 2.0f);
-	kp_adjusted.q = ((self->flux_approx_reference.q - self->flux_approx_real.q)/current_error.q) / (BO_factor * self->config.config_iq.samplingTime_sec * 2.0f);
 	if(self->config.Kp_adjustment_flag) {
-		uz_CurrentControl_set_Kp_id(self, kp_adjusted.d);
-		uz_CurrentControl_set_Kp_iq(self, kp_adjusted.q);
+		current_error.d = i_reference_Ampere.d - i_actual_Ampere.d;
+		if (fabsf(current_error.d) >= 0.001f) {//Only update Kp if error is significant enough
+			self->kp_adjustment_parameter.d = ((self->flux_approx_reference.d - self->flux_approx_real.d) / current_error.d) / (BO_factor * self->config.config_id.samplingTime_sec * 2.0f);
+			if (self->kp_adjustment_parameter.d > self->config.Kp_d_limit) {
+				self->kp_adjustment_parameter.d = self->config.Kp_d_limit;
+			}
+			uz_CurrentControl_set_Kp_id(self, self->kp_adjustment_parameter.d);
+		}
+
+		current_error.q = i_reference_Ampere.q - i_actual_Ampere.q ;
+		if (fabsf(current_error.q) >= 0.001f) {//Only update Kp if error is significant enough
+			self->kp_adjustment_parameter.q = ((self->flux_approx_reference.q - self->flux_approx_real.q)/current_error.q) / (BO_factor * self->config.config_iq.samplingTime_sec * 2.0f);
+			if (self->kp_adjustment_parameter.q > self->config.Kp_q_limit) {
+				self->kp_adjustment_parameter.q = self->config.Kp_q_limit;
+			}
+			uz_CurrentControl_set_Kp_iq(self, self->kp_adjustment_parameter.q);
+		}
 	}
 }
 

--- a/vitis/software/Baremetal/src/uz/uz_CurrentControl/uz_CurrentControl.h
+++ b/vitis/software/Baremetal/src/uz/uz_CurrentControl/uz_CurrentControl.h
@@ -28,6 +28,8 @@ struct uz_CurrentControl_config {
 	uz_PMSM_t config_PMSM; /**< Configuration struct for PMSM parameters */
 	bool Kp_adjustment_flag; /**<Flag to turn the adjustment of Kp via nonlinear flux-maps (gain scheduling) on or off */
 	float max_modulation_index; /**< Max possible modulation index for the chosen modulation method. I.e. 1/sqrt(3) for Space-Vector-Modulation*/
+	float Kp_d_limit; /**< Limit for the highest Kp-value for the d-axis the gain-scheduling can output. Set Kp_limit to e.g. 2x the Kp value calculated with linear Ld*/
+	float Kp_q_limit; /**< Limit for the highest Kp-value for the q-axis the gain-scheduling can output. Set Kp_limit to e.g. 2x the Kp value calculated with linear Lq*/
 };
 
 /**

--- a/vitis/software/Baremetal/test/uz/uz_CurrentControl/test_uz_CurrentControl.c
+++ b/vitis/software/Baremetal/test/uz/uz_CurrentControl/test_uz_CurrentControl.c
@@ -32,6 +32,8 @@ void setUp(void)
     config.config_iq.upper_limit = 10.0f;
     config.config_iq.lower_limit = -10.0f;
     config.Kp_adjustment_flag = false;
+    config.Kp_d_limit = 20.0f;
+    config.Kp_q_limit = 20.0f;
     i_actual_Ampere.d = 0.0f;
     i_actual_Ampere.q = 0.0f;
     i_actual_Ampere.zero = 0.0f;
@@ -221,6 +223,17 @@ void test_uz_CurrentControl_set_Kp_and_Ki_iq(void){
 void test_uz_CurrentControl_adjust_Kp_NULL(void) {
     TEST_ASSERT_FAIL_ASSERT(uz_CurrentControl_adjust_Kp(NULL,i_reference_Ampere,i_actual_Ampere,factor));
 }
+
+void test_uz_CurrentControl_init_kp_d_q_limit_assert(void) {
+    //test if the kp adjustment is written properly 
+    config.Kp_adjustment_flag = true;
+    config.Kp_d_limit = 0.0f;
+    TEST_ASSERT_FAIL_ASSERT(uz_CurrentControl_init(config));
+    config.Kp_d_limit = 20.0f;
+    config.Kp_q_limit = 0.0f;
+    TEST_ASSERT_FAIL_ASSERT(uz_CurrentControl_init(config));
+}
+
 void test_uz_CurrentControl_adjust_Kp(void){
     //test if the kp adjustment is written properly 
     config.Kp_adjustment_flag = true;
@@ -481,6 +494,30 @@ void test_uz_CurrentControl_set_Kp_adjustment_flag(void) {
     uz_CurrentControl_adjust_Kp(instance,i_reference_Ampere,i_actual_Ampere,factor);
     float result = uz_CurrentControl_get_Kp_iq(instance);
     TEST_ASSERT_FLOAT_WITHIN(1e-03f,7.5f,result);
+}
+
+void test_uz_CurrentControl_test_Kp_adjustment_limits(void) {
+    //Values for comparision from simulation 
+    config.Kp_adjustment_flag = true;
+    config.config_iq.samplingTime_sec = 0.0001f;
+    config.config_id.samplingTime_sec = 0.0001f;
+    uz_CurrentControl_t* instance = uz_CurrentControl_init(config);
+    flux_approx_reference.q = 0.002f;
+    flux_approx_real.q = 0.0005f;
+    flux_approx_reference.d = 0.002f;
+    flux_approx_real.d = 0.0005f;
+    i_reference_Ampere.q = 1.0f;
+    i_actual_Ampere.q = 0.5f;
+    i_reference_Ampere.d = 1.0f;
+    i_actual_Ampere.d = 0.5f;
+    //Set factor to such a low value, so that Kp would be absurdly high to test the limits
+    factor = 0.0001f;
+    uz_CurrentControl_set_flux_approx(instance,flux_approx_real, flux_approx_reference);
+    uz_CurrentControl_adjust_Kp(instance,i_reference_Ampere,i_actual_Ampere,factor);
+    float result_iq = uz_CurrentControl_get_Kp_iq(instance);
+    TEST_ASSERT_FLOAT_WITHIN(1e-03f,config.Kp_q_limit,result_iq);
+    float result_id = uz_CurrentControl_get_Kp_id(instance);
+    TEST_ASSERT_FLOAT_WITHIN(1e-03f,config.Kp_d_limit,result_id);
 }
 
 void test_uz_CurrentControl_tune_magnitude_optimum(void){


### PR DESCRIPTION
**Migrated from Bitbucket**
- Original Author: **Dennis Hufnagel** *(no GitHub account)*
- Original Created: March 30, 2026 at 02:35 PM UTC
- Original URL: https://bitbucket.org/ultrazohm/ultrazohm_sw/pull-requests/556

---

#### Summary: What kind of change does this PR introduce?

* improve gain scheduling logic if current error approaches zero
* Includes max value limit for Kp

#### What is the current behavior?

* If current error approaches zero, the calculation of Kp can become unstable.
* No limit for calculated Kps exist

#### What is the new behavior?

* If the current error is less than 0.001, no new Kp is calculated and the Kp of the previous time step is used
* Introduces a limit for the Kp values which can be set via the CC-config. If the calculated Kp is larger than this limit, the limit is output.

#### Does this PR introduce a breaking change?

* no

#### Which tests have to be done by reviewers before approving?

* rtfd
* check code

#### Other information:

* 

#### Please check if the PR fulfills these requirements

* Build pipelines pass
* Tests for the changes have been defined
* Docs have been added/updated

‌
