### PR TITLE
Logging Path: R5->ring buffer->A53

### DIFF
--- a/vitis/software/Baremetal/src/include/javascope.h
+++ b/vitis/software/Baremetal/src/include/javascope.h
@@ -49,6 +49,7 @@ enum JS_OberservableData {
 	JSO_Ld_mH,
 	JSO_Lq_mH,
 	JSO_PsiPM_mVs,
+	JSO_ipc_dropped_frames,
 	JSO_ENDMARKER
 };
 

--- a/vitis/software/Baremetal/src/sw/isr.c
+++ b/vitis/software/Baremetal/src/sw/isr.c
@@ -50,6 +50,7 @@ static void uz_r5_gic_reset_active_pl_interrupts(XScuGic *Gic);
 void ISR_Control(void *data)
 {
     uz_SystemTime_ISR_Tic(); // Reads out the global timer, has to be the first function in the isr
+    /*
     ReadAllADC();
     update_speed_and_position_of_encoder_on_D5(&Global_Data);
 
@@ -69,6 +70,7 @@ void ISR_Control(void *data)
                         Global_Data.rasv.halfBridge2DutyCycle,
                         Global_Data.rasv.halfBridge3DutyCycle);
     
+                        */
     JavaScope_update(&Global_Data);
     // Read the timer value at the very end of the ISR to minimize measurement error
     // This has to be the last function executed in the ISR!

--- a/vitis/software/Baremetal/src/sw/javascope.c
+++ b/vitis/software/Baremetal/src/sw/javascope.c
@@ -36,6 +36,7 @@ static float ISR_execution_time_us;
 static float ISR_period_us;
 static float System_UpTime_seconds;
 static float System_UpTime_ms;
+static float ipc_dropped_frames;   // R5->A53 ring frames dropped (ring full), as a JS channel
 
 uint32_t pollErrorCnt = 0U;
 
@@ -86,6 +87,7 @@ int JavaScope_initialize(DS_Data* data)
 	js_ch_observable[JSO_ISR_ExecTime_us] 		= &ISR_execution_time_us;
 	js_ch_observable[JSO_lifecheck]   			= &lifecheck;
 	js_ch_observable[JSO_ISR_Period_us]			= &ISR_period_us;
+	js_ch_observable[JSO_ipc_dropped_frames] 	= &ipc_dropped_frames;
 
 	// Store slow / not-time-critical signals into the SlowData-Array.
 	// Will be transferred one after another
@@ -102,20 +104,31 @@ int JavaScope_initialize(DS_Data* data)
 	js_slowDataArray[JSSD_FLOAT_ISR_Period_us] 			= &ISR_period_us;
 	js_slowDataArray[JSSD_FLOAT_Milliseconds]			= &System_UpTime_ms;
 
+	// Reset the R5->A53 sample ring header so a warm boot does not start from
+	// stale OCM indices.  The R5 owns init and runs before the control ISR is
+	// enabled (and thus before the A53 ever drains).
+	struct javascope_ring_t volatile * const js_ring = (struct javascope_ring_t*)MEM_SHARED_START_OCM_BANK_3_JAVASCOPE_RING;
+	js_ring->write_idx = 0U;
+	js_ring->read_idx  = 0U;
+	js_ring->dropped   = 0U;
+	Xil_DCacheFlushRange((INTPTR)js_ring, JAVASCOPE_RING_META_BYTES);
+
 	return Status;
 }
 
 
 void JavaScope_update(DS_Data* data){
 
-	// create pointer of type struct javascope_data_t named javascope_data located at MEM_SHARED_START_OCM_BANK_3_JAVASCOPE
-	struct javascope_data_t volatile * const javascope_data = (struct javascope_data_t*)MEM_SHARED_START_OCM_BANK_3_JAVASCOPE;
+	// R5 -> A53 JavaScope sample ring in shared OCM bank 3
+	struct javascope_ring_t volatile * const js_ring = (struct javascope_ring_t*)MEM_SHARED_START_OCM_BANK_3_JAVASCOPE_RING;
 	struct APU_to_RPU_t Received_Data_from_A53 = {0};
 	// create pointers to user data variables located in OCM Bank 1 and 2
 	struct RPU_to_APU_user_data_t volatile * const rpu_to_apu_user_data = (struct RPU_to_APU_user_data_t*)MEM_SHARED_START_OCM_BANK_1_RPU_TO_APU;
 	struct APU_to_RPU_user_data_t volatile * const apu_to_rpu_user_data = (struct APU_to_RPU_user_data_t*)MEM_SHARED_START_OCM_BANK_2_APU_TO_RPU;
 	static int js_cnt_slowData=0;
+	static uint32_t js_notify_pending=0U;   // frames written since the last IPI
 	int status = XST_SUCCESS;
+	int notified = 0;                       // did we trigger an IPI this frame?
 
 #if (USE_A53_AS_ACCELERATOR_FOR_R5_ISR == TRUE)
 	// write data to a53 in shared memory and flush cache
@@ -132,21 +145,50 @@ void JavaScope_update(DS_Data* data){
 	System_UpTime_seconds   = uz_SystemTime_GetUptimeInSec();
 	System_UpTime_ms		= uz_SystemTime_GetUptimeInMs();
 
-	// write data to shared memory
+	// Mirror the R5-owned ring drop counter for the JavaScope observable channel
+	// (R5 owns dropped, so it reads back its own cached value — no invalidate).
+	ipc_dropped_frames = (float)js_ring->dropped;
+
+	// Build one frame locally, then publish it into the ring buffer.
+	struct javascope_data_t sample;
 	for(int j=0; j<JS_CHANNELS; j++){
-		javascope_data->scope_ch[j] = *js_ch_selected[j];
+		sample.scope_ch[j] = *js_ch_selected[j];
 	}
-	javascope_data->slowDataID 		= js_cnt_slowData;
-	javascope_data->slowDataContent = *js_slowDataArray[js_cnt_slowData];
-	javascope_data->status 			= js_status_BareToRTOS;
+	sample.slowDataID 		= js_cnt_slowData;
+	sample.slowDataContent  = *js_slowDataArray[js_cnt_slowData];
+	sample.status 			= js_status_BareToRTOS;
 
-	// flush data cache of shared memory region to make sure shared memory is updated
-	Xil_DCacheFlushRange(MEM_SHARED_START_OCM_BANK_3_JAVASCOPE, JAVASCOPE_DATA_SIZE);
+	// R5 owns write_idx; read the A53-owned read_idx fresh to test for "full".
+	Xil_DCacheInvalidateRange((INTPTR)&js_ring->read_idx, sizeof(uint32_t));
+	uint32_t w = js_ring->write_idx;
+	uint32_t r = js_ring->read_idx;
 
-	//Send an interrupt to APU
-	status = XIpiPsu_TriggerIpi(&IPI_instance,XPAR_XIPIPS_TARGET_PSU_CORTEXA53_0_CH0_MASK);
-	if(status != (u32)XST_SUCCESS) {
-		xil_printf("RPU: IPI Trigger failed\r\n");
+	if (((w - r) & JAVASCOPE_RING_MASK) == JAVASCOPE_RING_MASK) {
+		// Ring full: drop newest, publish write_idx+dropped, and kick the A53.
+		js_ring->dropped++;
+		Xil_DCacheFlushRange((INTPTR)&js_ring->write_idx, 2U * sizeof(uint32_t));
+		if (js_notify_pending > 0U) {
+			notified = 1;
+			js_notify_pending = 0U;
+		}
+	} else {
+		js_ring->slots[w & JAVASCOPE_RING_MASK] = sample;
+		Xil_DCacheFlushRange((INTPTR)&js_ring->slots[w & JAVASCOPE_RING_MASK], JAVASCOPE_DATA_SIZE);
+		js_ring->write_idx = w + 1U;   // advance in R5 cache; published on notify
+		// Decimated notify: publish write_idx + IPI every Nth frame.
+		if (++js_notify_pending >= JAVASCOPE_RING_NOTIFY_DECIM) {
+			Xil_DCacheFlushRange((INTPTR)&js_ring->write_idx, sizeof(uint32_t));
+			notified = 1;
+			js_notify_pending = 0U;
+		}
+	}
+
+	//Send an interrupt to APU only on notify frames
+	if (notified) {
+		status = XIpiPsu_TriggerIpi(&IPI_instance,XPAR_XIPIPS_TARGET_PSU_CORTEXA53_0_CH0_MASK);
+		if(status != (u32)XST_SUCCESS) {
+			xil_printf("RPU: IPI Trigger failed\r\n");
+		}
 	}
 
 #if (USE_A53_AS_ACCELERATOR_FOR_R5_ISR == TRUE)
@@ -157,14 +199,16 @@ void JavaScope_update(DS_Data* data){
 	}
 #endif
 
-	u32 ControlData_length = sizeof(Received_Data_from_A53)/sizeof(float); // XIpiPsu_WriteMessage expects number of 32bit values as message length
-
-	//Afterwards the acknowledge a message from the APU can be read/checked, if a53 is enabled for external calculations of the r5 we wait for the acknowledge flag,
-	//if not, we don't do it in order to guarantee that the control-ISR never waits and always runs! -> This is due to the Polling of the acknowledge flag.
-	status = XIpiPsu_ReadMessage(&IPI_instance, XPAR_XIPIPS_TARGET_PSU_CORTEXA53_0_CH0_MASK, (u32*)(&Received_Data_from_A53), ControlData_length, XIPIPSU_BUF_TYPE_RESP);
-
-	if(status != (u32)XST_SUCCESS) {
-		xil_printf("RPU: IPI reading from A53 failed\r\n");
+	// Read the A53's response (one popped control command) ONLY on frames where
+	// we actually notified.  The A53 refreshes the response buffer once per IPI,
+	// so reading it on non-notify frames would re-dispatch the same command
+	// (the response is decimated together with the IPI).
+	if (notified) {
+		u32 ControlData_length = sizeof(Received_Data_from_A53)/sizeof(float); // number of 32-bit words
+		status = XIpiPsu_ReadMessage(&IPI_instance, XPAR_XIPIPS_TARGET_PSU_CORTEXA53_0_CH0_MASK, (u32*)(&Received_Data_from_A53), ControlData_length, XIPIPSU_BUF_TYPE_RESP);
+		if(status != (u32)XST_SUCCESS) {
+			xil_printf("RPU: IPI reading from A53 failed\r\n");
+		}
 	}
 
 	js_cnt_slowData++;

--- a/vitis/software/Baremetal/src/uz/uz_global_configuration.h
+++ b/vitis/software/Baremetal/src/uz/uz_global_configuration.h
@@ -31,7 +31,7 @@
 #define INTERRUPT_ADC_TO_ISR_RATIO_USER_CHOICE  1U  // Trigger the ADC at every PWM event, but trigger ISR_Control only every N-th interrupt event
 #define ADC_TRIGGER_DELAY_IN_US                 0.01f // ADC trigger delay in us; applies in both ISR trigger modes. 10ns delay to keep default behavior. See uz_mux_axi in docs.
 
-#define UZ_PWM_FREQUENCY                        10.0e3f
+#define UZ_PWM_FREQUENCY                        150.0e3f
 #define UZ_PWM_DEADTIME_IN_US                   1.0f
 #define UZ_PWM_MINIMUM_PULSE_WIDTH_IN_US        0.5f
 

--- a/vitis/software/FreeRTOS/sw/isr.c
+++ b/vitis/software/FreeRTOS/sw/isr.c
@@ -55,42 +55,53 @@ static void uz_a53_gic_reset_active_ipi_interrupts(XScuGic *Gic);
  */
 void APU_IPI_ISR(void *data)
 {
-	// create pointer to javascope_data_t named javascope_data located at MEM_SHARED_START_OCM_BANK_3_JAVASCOPE
-	struct javascope_data_t volatile * const javascope_data = (struct javascope_data_t*)MEM_SHARED_START_OCM_BANK_3_JAVASCOPE;
+	// R5 -> A53 JavaScope sample ring in shared OCM bank 3
+	struct javascope_ring_t volatile * const js_ring = (struct javascope_ring_t*)MEM_SHARED_START_OCM_BANK_3_JAVASCOPE_RING;
 	// create pointers to user data variables located in OCM Bank 1 and 2
 	struct RPU_to_APU_user_data_t volatile * const rpu_to_apu_user_data = (struct RPU_to_APU_user_data_t*)MEM_SHARED_START_OCM_BANK_1_RPU_TO_APU;
 	struct APU_to_RPU_user_data_t volatile * const apu_to_rpu_user_data = (struct APU_to_RPU_user_data_t*)MEM_SHARED_START_OCM_BANK_2_APU_TO_RPU;
 	int status;
 	BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
+	// Drain all ring slots the R5 has published since the last IPI.  The R5
+	// writes write_idx/dropped; invalidate that cache line before reading.
+	Xil_DCacheInvalidateRange((INTPTR)&js_ring->write_idx, 2U * sizeof(uint32_t));
+	uint32_t w = js_ring->write_idx;
+	uint32_t r = js_ring->read_idx;   // A53 owns read_idx
 
-	// R5 writes this shared region; invalidate A53 cache lines before reading it.
-	Xil_DCacheInvalidateRange( MEM_SHARED_START_OCM_BANK_3_JAVASCOPE, JAVASCOPE_DATA_SIZE);
-
-	// Queue samples only while a JavaScope TCP client is active.
-	if(js_connection_established!=0)
+	while (r != w)
 	{
-		size_t queue_status = xQueueSendToBackFromISR(js_queue, javascope_data, &xHigherPriorityTaskWoken);
+		struct javascope_data_t volatile * const slot = &js_ring->slots[r & JAVASCOPE_RING_MASK];
+		Xil_DCacheInvalidateRange((INTPTR)slot, JAVASCOPE_DATA_SIZE);
 
-		if (queue_status == errQUEUE_FULL)
+		// Maintain APU-local copy of status word (cf. main.c)
+		javascope_data_status = slot->status;
+
+		// Queue samples only while a JavaScope TCP client is active.
+		if(js_connection_established!=0)
 		{
-			js_queue_overflow_dropped_samples++;
-			js_queue_purge_requested = 1;
-			// The TCP worker observes this flag and purges the queued backlog.
-		}
-		else
-		{
-			// Yield to ethernet task only when the queue just crossed the send
-			// threshold. Avoids a context switch on every ISR invocation while
-			// still waking the sender without busy-poll delay.
-			if (uxQueueMessagesWaitingFromISR(js_queue) == JS_SAMPLES_PER_PACKET) {
+			size_t queue_status = xQueueSendToBackFromISR(js_queue, slot, &xHigherPriorityTaskWoken);
+
+			if (queue_status == errQUEUE_FULL)
+			{
+				js_queue_overflow_dropped_samples++;
+				js_queue_purge_requested = 1;
+				// The TCP worker observes this flag and purges the queued backlog.
+			}
+			else if (uxQueueMessagesWaitingFromISR(js_queue) == JS_SAMPLES_PER_PACKET)
+			{
+				// Yield to ethernet task only when the queue just crossed the send
+				// threshold. Avoids a context switch on every ISR invocation while
+				// still waking the sender without busy-poll delay.
 				portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 			}
 		}
+		r++;
 	}
 
-	// Maintain APU-local copy of status word (cf. main.c)
-	javascope_data_status = javascope_data->status;
+	// Publish the advanced read index so the R5 can reuse the drained slots.
+	js_ring->read_idx = r;
+	Xil_DCacheFlushRange((INTPTR)&js_ring->read_idx, sizeof(uint32_t));
 
 	// Consume at most one pending control command per ISR to preserve ordering.
 	// If no command is pending, send an explicit no-op (id=0) to avoid re-sending old commands.

--- a/vitis/software/shared/APU_RPU_shared.h
+++ b/vitis/software/shared/APU_RPU_shared.h
@@ -19,6 +19,47 @@ struct javascope_data_t
 	float       scope_ch[JS_CHANNELS];
 };
 
+// --- R5 -> A53 JavaScope sample ring buffer (shared OCM bank 3) -------------
+// The first 128 bytes of bank 3 stay reserved for the version handshake
+// (read_/write_apu/rpu_version below, at offsets 0 and 64); the ring follows.
+#define JAVASCOPE_RING_META_BYTES   128U
+#define MEM_SHARED_START_OCM_BANK_3_JAVASCOPE_RING \
+        (MEM_SHARED_START_OCM_BANK_3_JAVASCOPE + JAVASCOPE_RING_META_BYTES)
+
+#define JAVASCOPE_RING_SLOTS        512U                        // power of two
+#define JAVASCOPE_RING_MASK         (JAVASCOPE_RING_SLOTS - 1U)
+
+// Samples per APU interrupt: the R5 triggers an IPI every Nth frame (or
+// immediately when the ring fills), decimating the A53 interrupt rate.
+// 1 == notify every frame (previous behavior). Tune on hardware.
+#define JAVASCOPE_RING_NOTIFY_DECIM 16U
+
+// Header split so the R5-owned (write_idx/dropped) and A53-owned (read_idx)
+// fields occupy separate 64-byte cache lines (avoids false sharing).
+struct javascope_ring_t
+{
+	volatile uint32_t write_idx;     // R5 writes, A53 reads
+	volatile uint32_t dropped;       // R5 writes (frames dropped when ring full)
+	uint8_t  _pad0[64U - 2U * sizeof(uint32_t)];
+	volatile uint32_t read_idx;      // A53 writes, R5 reads
+	uint8_t  _pad1[64U - sizeof(uint32_t)];
+	// NOTE: sizeof(javascope_data_t) == 92 B is NOT a multiple of the cache-line
+	// size (R5 32 B / A53 64 B), so adjacent slots share cache lines.  This is
+	// safe for this single-producer/single-consumer ring: the R5 writes slots
+	// sequentially and flushes each by range, the A53 invalidates each slot by
+	// range before reading, and producer and consumer never touch the same slot
+	// concurrently.  Padding each slot to 64 B would push 512 slots past the
+	// 64 KB of OCM bank 3, so the unaligned layout is intentional.
+	struct javascope_data_t slots[JAVASCOPE_RING_SLOTS];
+};
+
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+_Static_assert((JAVASCOPE_RING_NOTIFY_DECIM >= 1U) && (JAVASCOPE_RING_NOTIFY_DECIM < JAVASCOPE_RING_SLOTS),
+               "JAVASCOPE_RING_NOTIFY_DECIM must be in [1, JAVASCOPE_RING_SLOTS).");
+_Static_assert((JAVASCOPE_RING_META_BYTES + sizeof(struct javascope_ring_t)) <= (64U * 1024U),
+               "JavaScope ring does not fit in OCM bank 3.");
+#endif
+
 struct APU_to_RPU_t
 {
 	uint32_t id;


### PR DESCRIPTION
**Migrated from Bitbucket**
- Original Author: @eykeyke
- Original Created: June 10, 2026 at 08:30 PM UTC
- Original URL: https://bitbucket.org/ultrazohm/ultrazohm_sw/pull-requests/581

---

## Summary: What kind of change does this PR introduce?

* Feature: a ring buffer in shared OCM for the R5→A53 JavaScope data, plus  
  interrupt decimation to lower the APU interrupt rate and the load on the R5.

## What is the current behavior?

* Each R5 ISR writes one frame to a single OCM slot and sends an IPI to the A53.
* The A53 has to run in-synch with R5 control code and is interrupted on every control cycle \(e.g. 10–20 kHz\).
* There is no buffer: a frame not read before the next ISR is overwritten.

## What is the new behavior?

* The R5 writes frames into a 512-slot ring in OCM bank 3.
* The R5 sends an IPI only every `JAVASCOPE_RING_NOTIFY_DECIM` frames \(default 16\),  
  or at once if the ring is full. The A53 reads all new frames per IPI.
* Result: the APU interrupt rate drops by N, the R5 does less work per frame,  
  and no samples are lost \(they are buffered, not overwritten\).
* Dropped frames \(ring full\) are counted and shown as a new channel  
  `JSO_ipc_dropped_frames`.

## Does this PR introduce a breaking change?

* No. The control protocol and GUI format do not change.
* Only the OCM data layout changes \(the ring starts at bank-3 offset 128; the  
  version-handshake bytes at 0 and 64 stay as before\).
* `JAVASCOPE_RING_NOTIFY_DECIM = 1` gives the old "IPI every frame" behavior.

## Which tests have to be done by reviewers before approving?

* Check the JavaScope stream has no gaps at full rate
* Check the APU interrupt rate drops by N and `ISR_ExecTime_us` does not rise.
* Try `JAVASCOPE_RING_NOTIFY_DECIM` = 1, 8, 16, 32: rate scales by 1/N, no loss.

## Other information:

* The ring header is reset in `JavaScope_initialize` so a warm boot does not use  
  stale indices \(the R5 inits before the A53 reads\).
* A frame is 92 bytes and not cache-line aligned, so slots share cache lines.  
  This is safe here \(one writer, one reader, range flush/invalidate\). Padding to  
  64 bytes would not fit 512 slots in the 64 KB bank. Noted in the header.

## Please check if the PR fulfills these requirements

* \[ \] Build pipelines pass 
* \[ \] Tests for the changes have been defined 
* \[ \] Docs have been added/updated — code comments only; no docs page changed

‌
