### PR TITLE
Feature/docs wolfspeed interface Rev04

### DIFF
--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/SCH_uz_per_wolfspeed_25kw_FM3_jlc_Rev04.pdf
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/SCH_uz_per_wolfspeed_25kw_FM3_jlc_Rev04.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24081b1a0e51c77e19e7232474c76ca50f6a8a0f99d0daf8b2cc401c685a31d2
+size 2574328

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/placeholder_rev04_overcurrent.svg
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/placeholder_rev04_overcurrent.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="360" viewBox="0 0 960 360" role="img" aria-labelledby="title desc">
+  <title id="title">Rev04 overcurrent placeholder</title>
+  <desc id="desc">Placeholder for an annotated overcurrent latch, indicator LED, and test jumper figure.</desc>
+  <rect width="960" height="360" fill="#f5f5f5"/>
+  <rect x="80" y="80" width="210" height="120" rx="6" fill="#ffffff" stroke="#555" stroke-width="3"/>
+  <rect x="380" y="80" width="210" height="120" rx="6" fill="#ffffff" stroke="#555" stroke-width="3"/>
+  <rect x="680" y="80" width="200" height="120" rx="6" fill="#ffffff" stroke="#555" stroke-width="3"/>
+  <path d="M290 140 H380 M590 140 H680" stroke="#333" stroke-width="4" fill="none"/>
+  <text x="185" y="150" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333">OC logic</text>
+  <text x="485" y="150" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333">Latch</text>
+  <text x="780" y="150" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333">LED / jumper</text>
+  <text x="480" y="300" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333">Placeholder: add annotated Rev04 overcurrent close-up</text>
+</svg>

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/placeholder_rev04_pcb_overview.svg
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/placeholder_rev04_pcb_overview.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="420" viewBox="0 0 960 420" role="img" aria-labelledby="title desc">
+  <title id="title">Rev04 PCB overview placeholder</title>
+  <desc id="desc">Placeholder for a top-side photo or 3D render of the Rev04 PCB.</desc>
+  <rect width="960" height="420" fill="#f5f5f5"/>
+  <rect x="80" y="80" width="800" height="260" rx="8" fill="#ffffff" stroke="#555" stroke-width="3"/>
+  <rect x="110" y="120" width="130" height="180" fill="#d9e8f5" stroke="#336b91" stroke-width="2"/>
+  <rect x="290" y="120" width="160" height="80" fill="#e6f0d8" stroke="#5f7f36" stroke-width="2"/>
+  <rect x="500" y="120" width="160" height="80" fill="#f4e2c6" stroke="#9a6a28" stroke-width="2"/>
+  <rect x="710" y="120" width="120" height="160" fill="#ead8ef" stroke="#764783" stroke-width="2"/>
+  <text x="480" y="370" font-family="Arial, sans-serif" font-size="26" text-anchor="middle" fill="#333">Placeholder: add total top-side view or 3D render of Rev04 PCB</text>
+</svg>

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/placeholder_rev04_temperature_pwm.svg
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/placeholder_rev04_temperature_pwm.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="360" viewBox="0 0 960 360" role="img" aria-labelledby="title desc">
+  <title id="title">Rev04 temperature PWM placeholder</title>
+  <desc id="desc">Placeholder for a temperature or NTC voltage to PWM duty-cycle transfer plot.</desc>
+  <rect width="960" height="360" fill="#f5f5f5"/>
+  <line x1="140" y1="260" x2="800" y2="260" stroke="#333" stroke-width="3"/>
+  <line x1="140" y1="260" x2="140" y2="70" stroke="#333" stroke-width="3"/>
+  <path d="M160 240 C300 220 430 180 560 130 S730 85 780 80" stroke="#2d6f8f" stroke-width="5" fill="none"/>
+  <text x="470" y="315" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333">NTC_ISO voltage or temperature</text>
+  <text x="80" y="175" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333" transform="rotate(-90 80 175)">Temp_PWM duty cycle</text>
+  <text x="480" y="40" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333">Placeholder: add measured or calculated transfer plot</text>
+</svg>

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/placeholder_rev04_test_setup.svg
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/placeholder_rev04_test_setup.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="420" viewBox="0 0 960 420" role="img" aria-labelledby="title desc">
+  <title id="title">Rev04 commissioning setup placeholder</title>
+  <desc id="desc">Placeholder for a photo of the Rev04 commissioning setup.</desc>
+  <rect width="960" height="420" fill="#f5f5f5"/>
+  <rect x="70" y="130" width="180" height="120" rx="6" fill="#ffffff" stroke="#555" stroke-width="3"/>
+  <rect x="390" y="100" width="180" height="180" rx="6" fill="#ffffff" stroke="#555" stroke-width="3"/>
+  <rect x="710" y="130" width="180" height="120" rx="6" fill="#ffffff" stroke="#555" stroke-width="3"/>
+  <path d="M250 170 H390 M570 170 H710" stroke="#336b91" stroke-width="5" fill="none"/>
+  <path d="M250 210 H390 M570 210 H710" stroke="#9a6a28" stroke-width="5" fill="none"/>
+  <text x="160" y="200" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333">UltraZohm</text>
+  <text x="480" y="195" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333">Rev04 PCB</text>
+  <text x="800" y="200" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333">Inverter</text>
+  <text x="480" y="350" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333">Placeholder: add commissioning setup photo</text>
+</svg>

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev03/rev03.rst
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev03/rev03.rst
@@ -1,8 +1,8 @@
 .. _uz_per_wolfspeed_25kw_FM3_rev03:
 
-================================================
+===========================================
 Wolfspeed Inverter 2L 25 kW Interface Rev03
-================================================
+===========================================
 
 Rev03 is the first productive revision of the ``uz_per_wolfspeed_25kw_FM3`` interface PCB.
 It interfaces the UltraZohm with the Wolfspeed ``CRD25DA12N-FMC`` inverter by replacing the original control card.

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev03/rev03.rst
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev03/rev03.rst
@@ -1,0 +1,136 @@
+.. _uz_per_wolfspeed_25kw_FM3_rev03:
+
+================================================
+Wolfspeed Inverter 2L 25 kW Interface Rev03
+================================================
+
+Rev03 is the first productive revision of the ``uz_per_wolfspeed_25kw_FM3`` interface PCB.
+It interfaces the UltraZohm with the Wolfspeed ``CRD25DA12N-FMC`` inverter by replacing the original control card.
+
+.. _uz_per_wolfspeed_rev03_function:
+
+.. figure:: ../InterfaceBoardLayout.png
+
+   Functional areas of the Rev03 interface PCB
+
+Layout
+======
+
+The PCB is structured by functional areas as shown in :ref:`uz_per_wolfspeed_rev03_function`.
+
+1. HFBR-1521Z/2521Z digital optical transmitters and receivers
+2. RJ45 port for analog signal transmission
+3. Driver stages for the optical links
+4. TI THS4561 fully differential amplifier stages
+5. Power section with TPS7A20 3.3 V LDO and REF35 voltage references
+6. Samtec HSEC8 120-pin edge-card connector mating with the Wolfspeed inverter
+
+Analog Signals
+==============
+
+The inverter-side analog signals are single-ended and are converted to fully differential signals for noise-robust transmission to the UltraZohm ADC board.
+The interface scales the single-ended signals by a factor of ``1.5038`` (``10 / 6.65``) to match the inverter-side 3.3 V analog range to the 5 V input range of the UltraZohm ADC board.
+
+The reported total sensing gain was measured experimentally and includes both the inverter-side measurement device and the interface board.
+The bandwidth was determined theoretically from LTSpice simulations.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 30 20
+
+   * - Signal
+     - Source
+     - Total measurement gain
+     - UltraZohm ADC channel
+   * - Phase current U
+     - LEM LAH 50-P
+     - 0.02417 V/A, bandwidth about 50 kHz
+     - ``I_U`` / Ch1
+   * - Phase current V
+     - LEM LAH 50-P
+     - 0.02417 V/A, bandwidth about 50 kHz
+     - ``I_V`` / Ch2
+   * - Phase current W
+     - LEM LAH 50-P
+     - 0.02417 V/A, bandwidth about 50 kHz
+     - ``I_W`` / Ch3
+   * - DC-link voltage
+     - Non-isolated voltage divider
+     - 0.003744 Vsec/Vprim, bandwidth about 7 kHz
+     - ``V_DC`` / Ch4
+
+Digital Signals
+===============
+
+Rev03 uses optical receivers for the UltraZohm-to-inverter PWM and gate-disable signals.
+The inverter-to-UltraZohm overcurrent and temperature signals use optical transmitters.
+
+The overcurrent detection signal is active low.
+When an overcurrent event is detected, the signal goes low and the transmitter LED is off.
+The default Wolfspeed overcurrent limits are set to approximately ``+/-79 A`` and can be adjusted with the reference resistors described in the Wolfspeed documentation.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 25 25
+
+   * - Signal
+     - Direction
+     - Conditioning
+     - Notes
+   * - ``U_HS_PWM``, ``U_LS_PWM``, ``V_HS_PWM``, ``V_LS_PWM``, ``W_HS_PWM``, ``W_LS_PWM``
+     - UltraZohm to inverter
+     - Optical receivers
+     - High-side and low-side PWM for three phases; dead time is generated in the UltraZohm.
+   * - ``GD_DIS``
+     - UltraZohm to inverter
+     - Optical receiver
+     - Global gate-driver disable signal.
+   * - ``OC``
+     - Inverter to UltraZohm
+     - SN74HCS08DR AND logic and optical transmitter
+     - Consolidated overcurrent signal from six comparator outputs.
+   * - ``NTC_ISO``
+     - Inverter to UltraZohm
+     - Optical transmitter
+     - Inverter-side temperature signal forwarded as a digital optical signal.
+
+Testing
+=======
+
+Rev03 was tested up to 10 kW with an RL load consisting of a 14 Ohm resistor and a 1 mH inductor.
+
+.. figure:: ../FinalSetup.png
+
+   Integrated testing setup with RL load
+
+Stable three-phase sinusoidal currents were measured using a Rohde & Schwarz MXO 5 series oscilloscope.
+
+.. figure:: ../Testgraph.png
+
+   Oscilloscope measurement at 100 kHz switching frequency with a 999 V / 8.33 A DC-link input
+
+Mechanical Support
+==================
+
+A 3D-printed support stand was added to keep the board mechanically stable when plugged into the inverter.
+The step file of the stand is available in the PCB repository.
+
+.. figure:: ../stand.jpg
+   :width: 60%
+   :align: center
+
+   Interface board with 3D-printed stand for mechanical stability
+
+Software Used for Testing
+=========================
+
+The inverter was tested with the ``feature/wolfspeed_inverter_adapterboard`` branch of the `ultrazohm_sw <https://bitbucket.org/ultrazohm/ultrazohm_sw/src/>`_ repository.
+The branch comparison is available `here <https://bitbucket.org/ultrazohm/ultrazohm_sw/branches/compare/feature%2Fwolfspeed_inverter_adapterboard%0Ddevelop#diff>`_.
+
+Documents
+=========
+
+* :download:`Schematic Rev03 <../SCH_uz_per_wolfspeed_25kw_FM3_jlc_Rev03.pdf>`
+* :download:`Bachelor thesis <../Thesis_Park_BA_UltraZohm_Wolfspeed_2L_Inverter_compressed.pdf>`
+* :download:`Final presentation <../FinalPresentation.pdf>`
+* :download:`Poster KI-Power Symposium <../Poster_UZandWolfspeedInterface.pptx>`

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04.rst
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04.rst
@@ -145,151 +145,159 @@ The OC trips at ``+/-49 A``.
 
    Jumper setup for overcurrent comparators.
 
-Inverter Temperature Measurement
-================================
 
-Rev04 converts the isolated NTC voltage to an optical PWM signal.
-The ``NTC_ISO`` from the inverter PCB is expected to be in the range of ``0 V`` to ``2 V`` and a voltage divider on the Rev04 PCB reduces this to ``0 V`` to ``1 V`` for matching the input range of the PWM generator (LTC6992CS6-2).
+NTC_ISO conversion for inverter V2.0
+====================================
 
-The LTC6992CS6-2 is configured with:
+For the CRD25DA12N-FMC V2.0 inverter and adapter Rev04, the signal chain is ``NTC`` -> analog
+``NTC_ISO`` -> 1:2 adapter voltage divider -> LTC6992-2 -> optical ``Temp_PWM`` -> duty ratio.
 
-* ``R_SET = 68 kOhm``, resulting in approximately ``46 kHz`` PWM frequency.
-* ``DIVCODE = 2`` / ``N_DIV = 16`` from the ``182 kOhm`` and ``976 kOhm`` divider.
-* ``POL = 1`` so rising NTC temperature results in increasing duty cycle.
+The LTC6992-2 is configured with:
 
-Temperature from PWM Duty Cycle
-===============================
+* ``R_SET = 68 kOhm``, resulting in an approximately ``46 kHz`` PWM frequency.
+* ``DIVCODE = 2`` / ``N_DIV = 16``, selected by the ``182 kOhm`` and ``976 kOhm`` divider.
+* ``POL = 1``, so increasing NTC temperature results in increasing duty cycle.
 
-.. warning::
-   The following approximation is calculated from assumptions based on the inverter schematics. 
-   The duty cycle to temperature function has not been validated on real hardware.
-
-The module temperature is approximated from the measured PWM duty cycle using the following linear relationship:
+On the inverter, the NTC is in parallel with :math:`1.8\,\mathrm{k\Omega}`; this combination and
+:math:`2.2\,\mathrm{k\Omega}` form a divider supplied by :math:`5\,\mathrm{V}`. Consequently,
 
 .. math::
 
-   T(D) = 1.55 \cdot D + 13.639
+   R_{\mathrm{NTC}} = \frac{3960 V_{\mathrm{NTC\_ISO}}}
+   {9 - 4 V_{\mathrm{NTC\_ISO}}}.
 
-where:
-
-* :math:`D` is the PWM duty cycle in percent.
-* :math:`T` is the estimated temperature in degrees Celsius.
-
-For example, a duty cycle of ``25 %`` gives:
+The adapter and LTC6992-2 transfer functions are
 
 .. math::
 
-   T(25) = 1.55 \cdot 25 + 13.639 = 52.389\ ^\circ\mathrm{C}
+   V_{\mathrm{MOD}} = \frac{V_{\mathrm{NTC\_ISO}}}{2}, \qquad
+   D = \frac{0.9 - V_{\mathrm{MOD}}}{0.8}, \qquad
+   V_{\mathrm{NTC\_ISO}} = 1.8 - 1.6D,
 
+where :math:`D` is a ratio from ``0.0`` to ``1.0``. Thus,
 
-Temperature-over-Duty-Cycle Graph
----------------------------------
+.. math::
 
-.. plot::
-   :caption: Estimated module temperature as a function of PWM duty cycle.
-   :align: center
-   :include-source: false
+   R_{\mathrm{NTC}}(D) = \frac{3960(1.8 - 1.6D)}
+   {9 - 4(1.8 - 1.6D)}.
 
-   import matplotlib.pyplot as plt
-   import numpy as np
+Using the WolfPACK NTC approximation :math:`R_{25}=5\,\mathrm{k\Omega}` and
+:math:`\beta_{25/100}\approx3523\,\mathrm{K}`, the temperature follows from
 
-   # Duty-cycle points derived from the NTC model.
-   duty_points = np.array([
-       5.7,
-       8.8,
-       15.7,
-       23.4,
-       31.5,
-       43.6,
-       60.8,
-       72.9,
-       80.7,
-   ])
+.. math::
 
-   # Temperatures calculated using the linear regression.
-   temperature_points = 1.55 * duty_points + 13.639
+   T[{}^\circ\mathrm{C}] = \left[\frac{1}{298.15}
+   + \frac{1}{3523}\ln\left(\frac{R_{\mathrm{NTC}}}{5000}\right)\right]^{-1} - 273.15.
 
-   # Continuous regression line.
-   duty = np.linspace(5.0, 95.0, 500)
-   temperature = 1.55 * duty + 13.639
-
-   plt.figure(figsize=(8, 5))
-
-   plt.plot(
-       duty,
-       temperature,
-       label=r"$T = 1.55D + 13.639$",
-   )
-
-   plt.scatter(
-       duty_points,
-       temperature_points,
-       label="Calculated data points",
-       zorder=3,
-   )
-
-   for duty_value, temperature_value in zip(
-       duty_points,
-       temperature_points,
-   ):
-       plt.annotate(
-           f"{temperature_value:.1f} °C",
-           (duty_value, temperature_value),
-           xytext=(5, 5),
-           textcoords="offset points",
-           fontsize=8,
-       )
-
-   plt.xlabel("PWM duty cycle (%)")
-   plt.ylabel("Estimated temperature (°C)")
-   plt.title("Estimated Temperature from PWM Duty Cycle")
-   plt.xlim(0, 100)
-   plt.grid(True)
-   plt.legend()
-   plt.tight_layout()
-
-
-Reference Data
+Clamp behavior
 --------------
 
-The following table contains the previously estimated NTC-model data and
-the corresponding result from the linear regression.
+The LTC6992-2 clamps its PWM output outside the nominal ``5 %`` to ``95 %`` duty-cycle range.
+Below or above these limits the PWM does not contain an unambiguous temperature. The lower clamp
+corresponds to approximately :math:`T\leq36.6\,{}^\circ\mathrm{C}` and the upper clamp to
+:math:`T\geq154.1\,{}^\circ\mathrm{C}`. The implementation returns these boundary values instead
+of extrapolating outside the valid range.
 
-.. list-table:: Duty-cycle and temperature reference values
+.. list-table:: Approximate reference values
    :header-rows: 1
-   :widths: 25 35 40
-   :align: center
+   :widths: 25 25 50
 
-   * - Duty cycle
-     - NTC-model estimate
-     - Linear-regression result
-   * - 5.7 %
-     - 25.0 °C
-     - 22.5 °C
-   * - 8.8 %
-     - 30.1 °C
-     - 27.3 °C
-   * - 15.7 %
-     - 40.0 °C
-     - 38.0 °C
-   * - 23.4 %
-     - 50.0 °C
-     - 49.9 °C
-   * - 31.5 %
-     - 60.0 °C
-     - 62.5 °C
-   * - 43.6 %
-     - 75.0 °C
-     - 81.2 °C
-   * - 60.8 %
-     - 100.0 °C
-     - 107.9 °C
-   * - 72.9 %
-     - 124.9 °C
-     - 126.6 °C
-   * - 80.7 %
-     - 149.9 °C
-     - 138.7 °C
+   * - Duty ratio
+     - Duty cycle
+     - Approximate temperature
+   * - :math:`D \leq 0.05`
+     - :math:`\leq 5\,\%`
+     - :math:`\leq 36.6\,{}^\circ\mathrm{C}`; lower clamp
+   * - 0.10
+     - 10 %
+     - 42 |degC|
+   * - 0.20
+     - 20 %
+     - 52 |degC|
+   * - 0.30
+     - 30 %
+     - 61 |degC|
+   * - 0.40
+     - 40 %
+     - 70 |degC|
+   * - 0.50
+     - 50 %
+     - 81 |degC|
+   * - 0.60
+     - 60 %
+     - 91 |degC|
+   * - 0.70
+     - 70 %
+     - 103 |degC|
+   * - 0.80
+     - 80 %
+     - 119 |degC|
+   * - 0.90
+     - 90 %
+     - 140 |degC|
+   * - :math:`D \geq 0.95`
+     - :math:`\geq 95\,\%`
+     - :math:`\geq 154.1\,{}^\circ\mathrm{C}`; upper clamp
+
+Conversion code
+---------------
+
+.. code-block:: c
+
+   #include <math.h>
+   #include "../include/wolfspeed_inverter_temperature.h"
+   #include "../uz/uz_HAL.h"
+
+   float wolfspeed_inverter_temperature_from_duty_ratio(float duty_ratio)
+   {
+       uz_assert(duty_ratio >= 0.0f);
+       uz_assert(duty_ratio <= 1.0f);
+
+       const float duty_min = 0.05f;
+       const float duty_max = 0.95f;
+       if (duty_ratio <= duty_min)
+       {
+           return 36.6f;
+       }
+       if (duty_ratio >= duty_max)
+       {
+           return 154.1f;
+       }
+
+       const float v_ntc_iso = 1.8f - 1.6f * duty_ratio;
+       const float r_ntc_ohm =
+           (3960.0f * v_ntc_iso) / (9.0f - 4.0f * v_ntc_iso);
+
+       const float r_25_ohm = 5000.0f;
+       const float beta_K = 3523.0f;
+       const float t_25_K = 298.15f;
+       const float inverse_temperature_K =
+           (1.0f / t_25_K)
+           + (logf(r_ntc_ohm / r_25_ohm) / beta_K);
+
+       const float temperature_K = 1.0f / inverse_temperature_K;
+       return temperature_K - 273.15f;
+   }
+
+The following application call has not yet been merged:
+
+.. code-block:: c
+
+   float const temperature_duty_ratio =
+       uz_PWM_duty_freq_detection_get_duty_cycle_in_percent(
+           Global_Data.objects.inverter_temperature_pwm);
+   Global_Data.av.inverter_temperature_pwm_duty_cycle_percent =
+       temperature_duty_ratio * 100.0f;
+   Global_Data.av.inverter_temperature_pwm_frequency_Hz =
+       uz_PWM_duty_freq_detection_get_frequency_in_Hz(
+           Global_Data.objects.inverter_temperature_pwm);
+   Global_Data.av.inverter_temperature_degC =
+       wolfspeed_inverter_temperature_from_duty_ratio(temperature_duty_ratio);
+
+.. note::
+   Despite the API name ``uz_PWM_duty_freq_detection_get_duty_cycle_in_percent``, the conversion
+   expects a ratio from ``0.0`` to ``1.0``. The example therefore multiplies the result by ``100.0f``
+   only when writing the ``_percent`` application variable.
 
 Commissioning Notes
 ===================

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04.rst
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04.rst
@@ -8,9 +8,23 @@ Rev04 is the second productive revision of the ``uz_per_wolfspeed_25kw_FM3`` int
 It keeps the Rev03 analog measurement concept and adds several digital functions for commissioning and inverter operation.
 The Rev04 schematic output was generated on 23.06.2026.
 
-.. figure:: ../placeholder_rev04_pcb_overview.svg
+.. figure:: rev04_pcb_overview_numbered.png
 
-   Figure placeholder: add a total top-side view or 3D render of the assembled Rev04 PCB.
+   Functional areas of the Rev04 interface PCB.
+
+Layout
+======
+
+The PCB is structured by functional areas as shown in :ref:`uz_per_wolfspeed_rev03_function`.
+
+1. HFBR-1521Z/2521Z digital optical transmitters and receivers
+2. RJ45 port for analog signal transmission
+3. Driver stages for the optical links
+4. TI THS4561 fully differential amplifier stages
+5. Power section with TPS7A20 3.3 V LDO and REF35 voltage references
+6. Samtec HSEC8 120-pin edge-card connector mating with the Wolfspeed inverter
+7. Window comparators, AND gates, and flip-flop for overcurrent detection and latch
+8. LTC6992 analog NTC temperature to PWM conversion 
 
 Changes Compared to Rev03
 =========================
@@ -34,24 +48,24 @@ The inverter-side phase-current and DC-link voltage measurements are converted f
 
    * - Signal
      - Source
-     - Conditioning
+     - Total measurement gain
      - UltraZohm ADC channel
-   * - ``IU_MEAS``
-     - Phase current U
-     - THS4561 fully differential amplifier
-     - Ch1
-   * - ``IV_MEAS``
-     - Phase current V
-     - THS4561 fully differential amplifier
-     - Ch2
-   * - ``IW_MEAS``
-     - Phase current W
-     - THS4561 fully differential amplifier
-     - Ch3
-   * - ``VDC_MEAS``
-     - DC-link voltage
-     - THS4561 fully differential amplifier
-     - Ch4
+   * - Phase current U
+     - LEM LAH 50-P
+     - 0.03993 V/A, bandwidth about 50 kHz
+     - ``I_U`` / Ch1
+   * - Phase current V
+     - LEM LAH 50-P
+     - 0.03993 V/A, bandwidth about 50 kHz
+     - ``I_V`` / Ch2
+   * - Phase current W
+     - LEM LAH 50-P
+     - 0.03993 V/A, bandwidth about 50 kHz
+     - ``I_W`` / Ch3
+   * - DC-link voltage
+     - Non-isolated voltage divider
+     - 0.003744 Vsec/Vprim, bandwidth about 7 kHz
+     - ``V_DC`` / Ch4
 
 Digital Signals
 ===============
@@ -68,14 +82,10 @@ Digital Signals
      - UltraZohm to inverter
      - Optical receivers
      - High-side and low-side PWM for three phases; dead time is generated in the UltraZohm.
-   * - ``Gate_Driver_Enable``
+   * - ``Gate_Driver_Enable`` (GD_DIS label on PCB port!)
      - UltraZohm to interface
      - Optical receiver, then inverter logic
      - High enables the gate drivers and arms overcurrent protection.
-   * - ``GD_DIS``
-     - Interface to inverter
-     - SN74LVC2GU04 inverter
-     - ``Gate_Driver_Enable`` high drives ``GD_DIS`` low, enabling the inverter gate drivers. ``Gate_Driver_Enable`` low drives ``GD_DIS`` high, disabling the gate drivers.
    * - ``FAN1_OUT``, ``FAN2_OUT``
      - Interface to inverter
      - Derived from ``Gate_Driver_Enable``
@@ -86,8 +96,13 @@ Digital Signals
      - Combined and latched overcurrent feedback. The latch clears when ``Gate_Driver_Enable`` is low.
    * - ``Temp_PWM``
      - Interface to UltraZohm
-     - LTC6992 PWM generator and optical transmitter
+     - LTC6992CS6-2 PWM generator and optical transmitter
      - PWM representation of the isolated NTC voltage.
+
+.. warning::
+   The printed label on the PCB called ``GD_DIS`` for the optical receiver is wrong. 
+   Actually this is ``Gate_Driver_Enable``, a high-active enable signal.
+
 
 Gate Enable and Fan Control
 ===========================
@@ -112,88 +127,196 @@ The schematic states the following behavior:
 Overcurrent Detection
 =====================
 
-The Rev04 overcurrent section uses TLV3502 comparators for the six phase-leg overcurrent signals:
+The Rev04 overcurrent section uses TLV3502 comparators for the three phase-leg overcurrent signals:
 ``U_HI_OC``, ``U_LO_OC``, ``V_HI_OC``, ``V_LO_OC``, ``W_HI_OC`` and ``W_LO_OC``.
 The comparator outputs are combined with SN74HCS08DR logic.
 The result is latched with an SN74LVC1G74 flip-flop and routed to the ``OC`` optical transmitter.
-
-The schematic documents ``OC_ALL_OK`` as high when no overcurrent event is present.
 When the gates are enabled, protection is armed.
 When the gates are disabled, the latch is cleared.
 
+The optical ``OC`` signal is high when an overcurrent event has been latched. Independently of a still 
+active ``Gate_Driver_Enable`` signal, the inverter gates are disabled until the ``OC`` latch is reset via 
+a low level of ``Gate_Driver_Enable``.
+
+The OC trips at ``+/-49 A``.
+
+
 .. note::
    Rev04 includes a 2x3 jumper header in the overcurrent section for testing overcurrent events.
-   Add a close-up figure of this header and label the normal-operation jumper setting before releasing operating instructions.
+   For normal operation, i.e., an active overcurrent detection, place the jumpers as stated in the explanatory figure, 
+   connecting left and right pins of each row.
 
-.. figure:: ../placeholder_rev04_overcurrent.svg
+.. figure:: rev04_oc_test_jumpers.png
+   :width: 60%
 
    Figure placeholder: add an annotated Rev04 schematic excerpt or PCB close-up of the overcurrent latch, indicator LED, and test jumper.
 
-Temperature PWM
-===============
+Inverter Temperature Measurement
+================================
 
 Rev04 converts the isolated NTC voltage to an optical PWM signal.
-The schematic notes that ``NTC_ISO`` is expected to be in the range ``0 V`` to ``2 V`` and that a voltage divider reduces this to ``0 V`` to ``1 V`` for the PWM generator.
+The ``NTC_ISO`` from the inverter PCB is expected to be in the range ``0 V`` to ``2 V`` and a voltage divider on the Rev04 PCB reduces this to ``0 V`` to ``1 V`` for matching the input range of the PWM generator (LTC6992CS6-2).
 
-The LTC6992 is configured with:
+The LTC6992CS6-2 is configured with:
 
 * ``R_SET = 68 kOhm``, resulting in approximately ``46 kHz`` PWM frequency.
 * ``DIVCODE = 2`` / ``N_DIV = 16`` from the ``182 kOhm`` and ``976 kOhm`` divider.
 * ``POL = 1`` so rising NTC temperature results in increasing duty cycle.
 
-.. figure:: ../placeholder_rev04_temperature_pwm.svg
+Temperature from PWM Duty Cycle
+===============================
 
-   Figure placeholder: add a small transfer plot showing NTC temperature or ``NTC_ISO`` voltage versus ``Temp_PWM`` duty cycle.
+.. warning::
+   The following approximation is calculated from assumptions based on the inverter schematics. 
+   The duty cycle to temperature function has not been validated on real hardware.
 
-Connector Notes
-===============
+The module temperature is approximated from the measured PWM duty cycle
+using the following linear regression:
 
-The Rev04 schematic shows the following relevant HSEC8 edge-card connector assignments.
-Use the schematic as the authority for complete pinout verification.
+.. math::
 
-.. list-table::
+   T(D) = 1.55 \cdot D + 13.639
+
+where:
+
+* :math:`D` is the PWM duty cycle in percent.
+* :math:`T` is the estimated temperature in degrees Celsius.
+
+For example, a duty cycle of 25 percent gives:
+
+.. math::
+
+   T(25) = 1.55 \cdot 25 + 13.639 = 52.389\ ^\circ\mathrm{C}
+
+
+Temperature-over-Duty-Cycle Graph
+---------------------------------
+
+.. plot::
+   :caption: Estimated module temperature as a function of PWM duty cycle.
+   :align: center
+   :include-source: false
+
+   import matplotlib.pyplot as plt
+   import numpy as np
+
+   # Duty-cycle points derived from the NTC model.
+   duty_points = np.array([
+       5.7,
+       8.8,
+       15.7,
+       23.4,
+       31.5,
+       43.6,
+       60.8,
+       72.9,
+       80.7,
+   ])
+
+   # Temperatures calculated using the linear regression.
+   temperature_points = 1.55 * duty_points + 13.639
+
+   # Continuous regression line.
+   duty = np.linspace(5.0, 95.0, 500)
+   temperature = 1.55 * duty + 13.639
+
+   plt.figure(figsize=(8, 5))
+
+   plt.plot(
+       duty,
+       temperature,
+       label=r"$T = 1.55D + 13.639$",
+   )
+
+   plt.scatter(
+       duty_points,
+       temperature_points,
+       label="Calculated data points",
+       zorder=3,
+   )
+
+   for duty_value, temperature_value in zip(
+       duty_points,
+       temperature_points,
+   ):
+       plt.annotate(
+           f"{temperature_value:.1f} °C",
+           (duty_value, temperature_value),
+           xytext=(5, 5),
+           textcoords="offset points",
+           fontsize=8,
+       )
+
+   plt.xlabel("PWM duty cycle (%)")
+   plt.ylabel("Estimated temperature (°C)")
+   plt.title("Estimated Temperature from PWM Duty Cycle")
+   plt.xlim(0, 100)
+   plt.grid(True)
+   plt.legend()
+   plt.tight_layout()
+
+
+Reference Data
+--------------
+
+The following table contains the previously estimated NTC-model data and
+the corresponding result from the linear regression.
+
+.. list-table:: Duty-cycle and temperature reference values
    :header-rows: 1
-   :widths: 25 25 50
+   :widths: 25 35 40
+   :align: center
 
-   * - Signal
-     - HSEC8 pin
-     - Notes
-   * - ``VDC_MEAS``
-     - 27
-     - DC-link voltage measurement input from inverter.
-   * - ``IU_MEAS``, ``IV_MEAS``, ``IW_MEAS``
-     - 33, 37, 39
-     - Phase-current measurement inputs from inverter.
-   * - ``U_HS_PWM``, ``U_LS_PWM``
-     - 49, 51
-     - Phase U PWM outputs to inverter.
-   * - ``V_HS_PWM``, ``V_LS_PWM``
-     - 53, 55
-     - Phase V PWM outputs to inverter.
-   * - ``W_HS_PWM``, ``W_LS_PWM``
-     - 50, 52
-     - Phase W PWM outputs to inverter.
-   * - ``GD_DIS``
-     - 75
-     - Inverter-side gate-driver disable signal.
-   * - ``FAN1_OUT``, ``FAN2_OUT``
-     - 105, 107
-     - Fan-control outputs added in Rev04.
+   * - Duty cycle
+     - NTC-model estimate
+     - Linear-regression result
+   * - 5.7 %
+     - 25.0 °C
+     - 22.5 °C
+   * - 8.8 %
+     - 30.1 °C
+     - 27.3 °C
+   * - 15.7 %
+     - 40.0 °C
+     - 38.0 °C
+   * - 23.4 %
+     - 50.0 °C
+     - 49.9 °C
+   * - 31.5 %
+     - 60.0 °C
+     - 62.5 °C
+   * - 43.6 %
+     - 75.0 °C
+     - 81.2 °C
+   * - 60.8 %
+     - 100.0 °C
+     - 107.9 °C
+   * - 72.9 %
+     - 124.9 °C
+     - 126.6 °C
+   * - 80.7 %
+     - 149.9 °C
+     - 138.7 °C
 
 Commissioning Notes
 ===================
 
 Before first operation:
 
-* Verify that ``Gate_Driver_Enable`` polarity is implemented correctly in the FPGA and software.
-* Confirm that disabling ``Gate_Driver_Enable`` clears the overcurrent latch.
+* Mount the interface PCB with the two mentioned 3d-printed clamps tightly to the inverter. The .STL parts are available in the repository in: ``Altium\step\stl``
 * Check fan behavior before applying high DC-link voltage.
-* Verify the ``Temp_PWM`` duty-cycle interpretation in the software or FPGA logic.
-* Check the overcurrent test jumper setting against the schematic before operation.
+* Verify the temperature PWM duty-cycle interpretation in the software or FPGA logic.
+* Check the overcurrent test jumper setting. Three jumpers need to be placed in order to set the OC detection active.
 
-.. figure:: ../placeholder_rev04_test_setup.svg
+.. figure:: rev04_opt_connections.png
+   :width: 90%
 
-   Figure placeholder: add a photo of the Rev04 commissioning setup with UltraZohm, interface PCB, Wolfspeed inverter, optical links, RJ45 analog cable, fan wiring, and DC-link/load connections.
+   Commissioning of the interface PCB with optical signal connections, mechanical mounting, and active OC circuitry
+
+Known issues
+============
+
+* The printed label on the PCB called ``GD_DIS`` for the optical receiver is wrong. Actually this is ``Gate_Driver_Enable``, a high-active enable signal.
 
 Documents
 =========

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04.rst
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04.rst
@@ -1,27 +1,24 @@
 .. _uz_per_wolfspeed_25kw_FM3_rev04:
 
-================================================
+===========================================
 Wolfspeed Inverter 2L 25 kW Interface Rev04
-================================================
+===========================================
 
 Rev04 is the second productive revision of the ``uz_per_wolfspeed_25kw_FM3`` interface PCB.
-It keeps the Rev03 analog measurement concept and adds several digital functions for commissioning and inverter operation.
-The Rev04 schematic output was generated on 23.06.2026.
+Rev04 keeps the analog measurement concept of Rev03 and adds several digital functions for commissioning and inverter operation.
 
 .. figure:: rev04_pcb_overview_numbered.png
+   :width: 60%
 
    Functional areas of the Rev04 interface PCB.
 
-Layout
-======
-
-The PCB is structured by functional areas as shown in :ref:`uz_per_wolfspeed_rev03_function`.
+The PCB is structured by functional areas as shown in :ref:`uz_per_wolfspeed_rev03_function` with:
 
 1. HFBR-1521Z/2521Z digital optical transmitters and receivers
 2. RJ45 port for analog signal transmission
 3. Driver stages for the optical links
 4. TI THS4561 fully differential amplifier stages
-5. Power section with TPS7A20 3.3 V LDO and REF35 voltage references
+5. Power supply with TPS7A20 3.3 V LDO and REF35 voltage references
 6. Samtec HSEC8 120-pin edge-card connector mating with the Wolfspeed inverter
 7. Window comparators, AND gates, and flip-flop for overcurrent detection and latch
 8. LTC6992 analog NTC temperature to PWM conversion 
@@ -127,35 +124,32 @@ The schematic states the following behavior:
 Overcurrent Detection
 =====================
 
-The Rev04 overcurrent section uses TLV3502 comparators for the three phase-leg overcurrent signals:
+The Rev04 overcurrent (OC) detection uses TLV3502 comparators for the three phase-leg overcurrent signals:
 ``U_HI_OC``, ``U_LO_OC``, ``V_HI_OC``, ``V_LO_OC``, ``W_HI_OC`` and ``W_LO_OC``.
 The comparator outputs are combined with SN74HCS08DR logic.
 The result is latched with an SN74LVC1G74 flip-flop and routed to the ``OC`` optical transmitter.
 When the gates are enabled, protection is armed.
 When the gates are disabled, the latch is cleared.
 
-The optical ``OC`` signal is high when an overcurrent event has been latched. Independently of a still 
-active ``Gate_Driver_Enable`` signal, the inverter gates are disabled until the ``OC`` latch is reset via 
-a low level of ``Gate_Driver_Enable``.
-
+The optical ``OC`` signal is high when an overcurrent event has been detected, which latches the signal.
+The inverter gates are disabled until the ``OC`` latch is reset via a low signal on ``Gate_Driver_Enable``.
+Disabling the gate signals is independents of an active ``Gate_Driver_Enable`` signal.
 The OC trips at ``+/-49 A``.
-
 
 .. note::
    Rev04 includes a 2x3 jumper header in the overcurrent section for testing overcurrent events.
-   For normal operation, i.e., an active overcurrent detection, place the jumpers as stated in the explanatory figure, 
-   connecting left and right pins of each row.
+   For normal operation, i.e., an active overcurrent detection, place the jumpers as stated in the explanatory figure, connecting left and right pins of each row.
 
 .. figure:: rev04_oc_test_jumpers.png
    :width: 60%
 
-   Figure placeholder: add an annotated Rev04 schematic excerpt or PCB close-up of the overcurrent latch, indicator LED, and test jumper.
+   Jumper setup for overcurrent comparators.
 
 Inverter Temperature Measurement
 ================================
 
 Rev04 converts the isolated NTC voltage to an optical PWM signal.
-The ``NTC_ISO`` from the inverter PCB is expected to be in the range ``0 V`` to ``2 V`` and a voltage divider on the Rev04 PCB reduces this to ``0 V`` to ``1 V`` for matching the input range of the PWM generator (LTC6992CS6-2).
+The ``NTC_ISO`` from the inverter PCB is expected to be in the range of ``0 V`` to ``2 V`` and a voltage divider on the Rev04 PCB reduces this to ``0 V`` to ``1 V`` for matching the input range of the PWM generator (LTC6992CS6-2).
 
 The LTC6992CS6-2 is configured with:
 
@@ -170,8 +164,7 @@ Temperature from PWM Duty Cycle
    The following approximation is calculated from assumptions based on the inverter schematics. 
    The duty cycle to temperature function has not been validated on real hardware.
 
-The module temperature is approximated from the measured PWM duty cycle
-using the following linear regression:
+The module temperature is approximated from the measured PWM duty cycle using the following linear relationship:
 
 .. math::
 
@@ -182,7 +175,7 @@ where:
 * :math:`D` is the PWM duty cycle in percent.
 * :math:`T` is the estimated temperature in degrees Celsius.
 
-For example, a duty cycle of 25 percent gives:
+For example, a duty cycle of ``25 %`` gives:
 
 .. math::
 
@@ -303,7 +296,7 @@ Commissioning Notes
 
 Before first operation:
 
-* Mount the interface PCB with the two mentioned 3d-printed clamps tightly to the inverter. The .STL parts are available in the repository in: ``Altium\step\stl``
+* Mount the interface PCB with the two mentioned 3d-printed clamps tightly to the inverter. The .STL parts are available in the `PCB-repository <https://bitbucket.org/ultrazohm/uz_per_wolfspeed_25kw_fm3/src/main/Altium/step/stl/>`_.
 * Check fan behavior before applying high DC-link voltage.
 * Verify the temperature PWM duty-cycle interpretation in the software or FPGA logic.
 * Check the overcurrent test jumper setting. Three jumpers need to be placed in order to set the OC detection active.

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04.rst
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04.rst
@@ -204,40 +204,40 @@ of extrapolating outside the valid range.
 
    * - Duty ratio
      - Duty cycle
-     - Approximate temperature
+     - Approximate temperature in :math:`{}^\circ\mathrm{C}`
    * - :math:`D \leq 0.05`
      - :math:`\leq 5\,\%`
-     - :math:`\leq 36.6\,{}^\circ\mathrm{C}`; lower clamp
+     - :math:`\leq 36.6`; lower clamp
    * - 0.10
      - 10 %
-     - 42 |degC|
+     - 42 
    * - 0.20
      - 20 %
-     - 52 |degC|
+     - 52 
    * - 0.30
      - 30 %
-     - 61 |degC|
+     - 61 
    * - 0.40
      - 40 %
-     - 70 |degC|
+     - 70 
    * - 0.50
      - 50 %
-     - 81 |degC|
+     - 81 
    * - 0.60
      - 60 %
-     - 91 |degC|
+     - 91 
    * - 0.70
      - 70 %
-     - 103 |degC|
+     - 103 
    * - 0.80
      - 80 %
-     - 119 |degC|
+     - 119 
    * - 0.90
      - 90 %
-     - 140 |degC|
+     - 140 
    * - :math:`D \geq 0.95`
      - :math:`\geq 95\,\%`
-     - :math:`\geq 154.1\,{}^\circ\mathrm{C}`; upper clamp
+     - :math:`\geq 154.1`; upper clamp
 
 Conversion code
 ---------------

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04.rst
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04.rst
@@ -1,0 +1,202 @@
+.. _uz_per_wolfspeed_25kw_FM3_rev04:
+
+================================================
+Wolfspeed Inverter 2L 25 kW Interface Rev04
+================================================
+
+Rev04 is the second productive revision of the ``uz_per_wolfspeed_25kw_FM3`` interface PCB.
+It keeps the Rev03 analog measurement concept and adds several digital functions for commissioning and inverter operation.
+The Rev04 schematic output was generated on 23.06.2026.
+
+.. figure:: ../placeholder_rev04_pcb_overview.svg
+
+   Figure placeholder: add a total top-side view or 3D render of the assembled Rev04 PCB.
+
+Changes Compared to Rev03
+=========================
+
+* Added ``GateAndFanControl.SchDoc``: ``Gate_Driver_Enable`` is converted to the inverter ``GD_DIS`` polarity and also drives the fan-control output.
+* Added ``OvercurrentDetectionLogic.SchDoc``: the six overcurrent comparator outputs are combined, latched, reset by gate enable, and routed to the optical ``OC`` output.
+* Added ``TempSenseConditioning.SchDoc``: the analog isolated NTC signal is converted to a PWM signal before the optical transmitter.
+* Added fan outputs ``FAN1_OUT`` and ``FAN2_OUT`` on the inverter connector.
+* Added a red overcurrent latch indicator LED.
+* Added a 2x3 jumper header in the overcurrent section for testing overcurrent events.
+
+Analog Signals
+==============
+
+Rev04 keeps the Rev03 analog measurement structure.
+The inverter-side phase-current and DC-link voltage measurements are converted from single-ended signals to fully differential signals for the UltraZohm ADC board.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 30 20
+
+   * - Signal
+     - Source
+     - Conditioning
+     - UltraZohm ADC channel
+   * - ``IU_MEAS``
+     - Phase current U
+     - THS4561 fully differential amplifier
+     - Ch1
+   * - ``IV_MEAS``
+     - Phase current V
+     - THS4561 fully differential amplifier
+     - Ch2
+   * - ``IW_MEAS``
+     - Phase current W
+     - THS4561 fully differential amplifier
+     - Ch3
+   * - ``VDC_MEAS``
+     - DC-link voltage
+     - THS4561 fully differential amplifier
+     - Ch4
+
+Digital Signals
+===============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 25 25
+
+   * - Signal
+     - Direction
+     - Conditioning
+     - Notes
+   * - ``U_HS_PWM``, ``U_LS_PWM``, ``V_HS_PWM``, ``V_LS_PWM``, ``W_HS_PWM``, ``W_LS_PWM``
+     - UltraZohm to inverter
+     - Optical receivers
+     - High-side and low-side PWM for three phases; dead time is generated in the UltraZohm.
+   * - ``Gate_Driver_Enable``
+     - UltraZohm to interface
+     - Optical receiver, then inverter logic
+     - High enables the gate drivers and arms overcurrent protection.
+   * - ``GD_DIS``
+     - Interface to inverter
+     - SN74LVC2GU04 inverter
+     - ``Gate_Driver_Enable`` high drives ``GD_DIS`` low, enabling the inverter gate drivers. ``Gate_Driver_Enable`` low drives ``GD_DIS`` high, disabling the gate drivers.
+   * - ``FAN1_OUT``, ``FAN2_OUT``
+     - Interface to inverter
+     - Derived from ``Gate_Driver_Enable``
+     - Fans are on when ``Gate_Driver_Enable`` is high and off when it is low.
+   * - ``OC``
+     - Interface to UltraZohm
+     - SN74HCS08DR logic, SN74LVC1G74 latch, optical transmitter
+     - Combined and latched overcurrent feedback. The latch clears when ``Gate_Driver_Enable`` is low.
+   * - ``Temp_PWM``
+     - Interface to UltraZohm
+     - LTC6992 PWM generator and optical transmitter
+     - PWM representation of the isolated NTC voltage.
+
+Gate Enable and Fan Control
+===========================
+
+Rev04 separates the UltraZohm-side gate-enable command from the inverter-side disable polarity.
+The schematic states the following behavior:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - ``Gate_Driver_Enable``
+     - Resulting output
+     - Function
+   * - High
+     - ``GD_DIS`` low, ``FANx_OUT`` high
+     - Gate drivers enabled, fans on, overcurrent protection armed.
+   * - Low
+     - ``GD_DIS`` high, ``FANx_OUT`` low
+     - Gate drivers disabled, fans off, overcurrent latch cleared.
+
+Overcurrent Detection
+=====================
+
+The Rev04 overcurrent section uses TLV3502 comparators for the six phase-leg overcurrent signals:
+``U_HI_OC``, ``U_LO_OC``, ``V_HI_OC``, ``V_LO_OC``, ``W_HI_OC`` and ``W_LO_OC``.
+The comparator outputs are combined with SN74HCS08DR logic.
+The result is latched with an SN74LVC1G74 flip-flop and routed to the ``OC`` optical transmitter.
+
+The schematic documents ``OC_ALL_OK`` as high when no overcurrent event is present.
+When the gates are enabled, protection is armed.
+When the gates are disabled, the latch is cleared.
+
+.. note::
+   Rev04 includes a 2x3 jumper header in the overcurrent section for testing overcurrent events.
+   Add a close-up figure of this header and label the normal-operation jumper setting before releasing operating instructions.
+
+.. figure:: ../placeholder_rev04_overcurrent.svg
+
+   Figure placeholder: add an annotated Rev04 schematic excerpt or PCB close-up of the overcurrent latch, indicator LED, and test jumper.
+
+Temperature PWM
+===============
+
+Rev04 converts the isolated NTC voltage to an optical PWM signal.
+The schematic notes that ``NTC_ISO`` is expected to be in the range ``0 V`` to ``2 V`` and that a voltage divider reduces this to ``0 V`` to ``1 V`` for the PWM generator.
+
+The LTC6992 is configured with:
+
+* ``R_SET = 68 kOhm``, resulting in approximately ``46 kHz`` PWM frequency.
+* ``DIVCODE = 2`` / ``N_DIV = 16`` from the ``182 kOhm`` and ``976 kOhm`` divider.
+* ``POL = 1`` so rising NTC temperature results in increasing duty cycle.
+
+.. figure:: ../placeholder_rev04_temperature_pwm.svg
+
+   Figure placeholder: add a small transfer plot showing NTC temperature or ``NTC_ISO`` voltage versus ``Temp_PWM`` duty cycle.
+
+Connector Notes
+===============
+
+The Rev04 schematic shows the following relevant HSEC8 edge-card connector assignments.
+Use the schematic as the authority for complete pinout verification.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 50
+
+   * - Signal
+     - HSEC8 pin
+     - Notes
+   * - ``VDC_MEAS``
+     - 27
+     - DC-link voltage measurement input from inverter.
+   * - ``IU_MEAS``, ``IV_MEAS``, ``IW_MEAS``
+     - 33, 37, 39
+     - Phase-current measurement inputs from inverter.
+   * - ``U_HS_PWM``, ``U_LS_PWM``
+     - 49, 51
+     - Phase U PWM outputs to inverter.
+   * - ``V_HS_PWM``, ``V_LS_PWM``
+     - 53, 55
+     - Phase V PWM outputs to inverter.
+   * - ``W_HS_PWM``, ``W_LS_PWM``
+     - 50, 52
+     - Phase W PWM outputs to inverter.
+   * - ``GD_DIS``
+     - 75
+     - Inverter-side gate-driver disable signal.
+   * - ``FAN1_OUT``, ``FAN2_OUT``
+     - 105, 107
+     - Fan-control outputs added in Rev04.
+
+Commissioning Notes
+===================
+
+Before first operation:
+
+* Verify that ``Gate_Driver_Enable`` polarity is implemented correctly in the FPGA and software.
+* Confirm that disabling ``Gate_Driver_Enable`` clears the overcurrent latch.
+* Check fan behavior before applying high DC-link voltage.
+* Verify the ``Temp_PWM`` duty-cycle interpretation in the software or FPGA logic.
+* Check the overcurrent test jumper setting against the schematic before operation.
+
+.. figure:: ../placeholder_rev04_test_setup.svg
+
+   Figure placeholder: add a photo of the Rev04 commissioning setup with UltraZohm, interface PCB, Wolfspeed inverter, optical links, RJ45 analog cable, fan wiring, and DC-link/load connections.
+
+Documents
+=========
+
+* :download:`Schematic Rev04 <../SCH_uz_per_wolfspeed_25kw_FM3_jlc_Rev04.pdf>`
+* `PCB repository uz_per_wolfspeed_25kw_FM3 <https://bitbucket.org/ultrazohm/uz_per_wolfspeed_25kw_fm3/src/main/>`_

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04_oc_test_jumpers.png
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04_oc_test_jumpers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f531b71ce69182f7c6e7b057c3598dc09cf44581c16e55047f48bdac0ae5c87
+size 152997

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04_opt_connections.png
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04_opt_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:876a94104d8984617be7a8d800963d43f67873ca00c24570c475cc30f081e5cb
+size 5417387

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04_pcb_overview.png
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04_pcb_overview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdf7b8b29c7b00ce7c110ec089be15c27690bd4e71811c802be657c450bc2372
+size 665108

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04_pcb_overview_numbered.png
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/rev04/rev04_pcb_overview_numbered.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef75e6a2a4b4a77bd0de6e38d067509e5216b4067cce43175a978b6bc9f5fda8
+size 660279

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/uz_per_wolfspeed_25kw_FM3.rst
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/uz_per_wolfspeed_25kw_FM3.rst
@@ -36,10 +36,10 @@ Revision History
      - Not functional
      - Early hardware revision; no productive documentation in this repository.
    * - Rev03
-     - Productive
+     - Productive, **only for Inverter V1.1**
      - First functional and documented revision. Tested up to 10 kW with an RL load.
    * - Rev04
-     - Productive revision
+     - Productive revision, **only for Inverter V2.0**
      - Adds gate-enable derived fan control, overcurrent latch/reset logic, an optical temperature PWM output, and further hardware fixes.
 
 Common Function

--- a/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/uz_per_wolfspeed_25kw_FM3.rst
+++ b/docs/source/hardware/adapter_cards/external/uz_per_wolfspeed_25kw_FM3/uz_per_wolfspeed_25kw_FM3.rst
@@ -1,162 +1,77 @@
 .. _uz_per_wolfspeed_25kw_FM3:
 
-Wolfspeed Inverter 2L 25kW Interface
-====================================
+========================================
+Wolfspeed Inverter 2L 25 kW Interface
+========================================
 
-Source
-******
+The ``uz_per_wolfspeed_25kw_FM3`` interface PCB connects the UltraZohm to the Wolfspeed
+`CRD25DA12N-FMC 25 kW Three-Phase Inverter <https://www.wolfspeed.com/products/power/reference-designs/crd25da12n-fmc/>`_.
+It plugs into the inverter in place of the Texas Instruments control card and adapts the inverter signals to the UltraZohm analog and digital interfaces.
 
-- `PCB repository uz_per_wolfspeed_25kw_FM3 <https://bitbucket.org/ultrazohm/uz_per_wolfspeed_25kw_fm3/src/main/>`_
+Use this page as the entry point and select the page that matches the hardware revision in use.
 
-General Description
-*******************
+Revisions
+=========
 
-This PCB is designed to interface the UltraZohm with the Wolfspeed `CRD25DA12N-FMC 25 kW Three-Phase Inverter <https://www.wolfspeed.com/products/power/reference-designs/crd25da12n-fmc/>`_. 
-It plugs directly into the Wolfspeed inverter in place of the Texas Instruments TMDSCNCD280039C control card.
+.. toctree::
+   :maxdepth: 1
 
-Analog measurement signals are routed via an RJ45 connector to the UltraZohm ADC board using fully differential signaling. 
-Digital control and status signals are transmitted over optical links using HFBR transmitters/receivers.
+   rev03/rev03
+   rev04/rev04
 
-.. _Interface_board_function:
-
-.. figure:: InterfaceBoardLayout.png
-
-   Functional areas of the uz_per_wolfspeed inverter interface pcb
-
-Layout
-******
-
-The PCB is structured by functional areas as shown in :ref:`Interface_board_function`.
-
-1. HFBR-1521Z/2521Z Digital optical transmitters and receivers
-2. RJ45 port for analog signal transmission 
-3. Driver stages for the optical links
-4. TI THS4561 fully differential amplifier stages for differential signaling
-5. Power section: TPS7A20 (3.3V LDO), REF35 (2.5V and 1.7V references)
-6. Samtec HSEC8 120-pin edge-card connector mating with the Wolfspeed inverter
-
-
-
-Signal Description
-******************
-
-The interface board adapts all required signals between the Wolfspeed inverter and UltraZohm. 
-Signals are grouped as analog and digital.
-
-
-Analog Signals
---------------
-
-The signals on the inverter side are single-ended and converted to fully differential signals for noise-robust transmission to the UltraZohm ADC board.
-The adapter cards scales the single-ended signals by factor 1.5038 (10/6.65) to match the analog range of the Wolfspeed inverter (3.3V) to the 5V analog input range of the UltraZohm ADC board.
-The reported total sensing gain is measured experimentally, see attached thesis for details. 
-It includes the gain of the measurement device (e.g. current sensor) and the gain of the interface board.
-The bandwidth is determined theoretically based on an LTSpice simulation and the resulting -3dB point.
+Revision History
+================
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 20 30 30
+   :widths: 15 25 60
 
-   * - Signal
-     - Source
-     - Total Measurement Gain
-     - UltraZohm ADC Channel
-   * - Phase Currents U, V, W
-     - LEM LAH 50-P
-     - total sensing gain 0.02417 in V/A, bandwidth ~50kHz
-     - I_U (Ch1), I_V (Ch2), I_W (Ch3)
-   * - DC-Link Voltage
-     - voltage divider, non-isolated
-     - total sensing gain in 0.003744 Vsec/Vprim, bandwidth ~7kHz
-     - V_DC on Ch4 (RJ45 Pair 1-2)
-
-
-Digital Signals
----------------
-
-
-The overcurrent detection signal is active LOW, meaning that when an overcurrent condition is detected, the signal goes LOW and, therefore, the LED of the transmitter is OFF.
-The overcurrent limits are by default set to +-79A and can be adjusted by varying the reference resistors, as detailed in the Wolfspeed documentation.
-
-The NTC output is converted to a 50 kHz PWM signal with varying duty cycle. 
-
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 20 20 35
-
-   * - Signal
-     - Direction
-     - Conditioning
+   * - Revision
+     - Status
      - Notes
-   * - 6x PWM Gate Signals 
-     - UZ → Inverter
-     - Optical Rx
-     - High- and Low-Side for 3 phases, dead-time generated in UZ
-   * - Gate Driver Disable
-     - UZ → Inverter
-     - Optical Rx
-     - Global gate driver shutdown
-   * - 6x Overcurrent Detection
-     - Inverter → UZ
-     - AND-gates (SN74HCS08DR) + Optical Tx
-     - Consolidated into single fault signal (active-LOW)
-   * - NTC Temperature
-     - Inverter → UZ
-     - Optical Tx
-     - PWM modulated signal at 50kHz
+   * - Rev01
+     - Not functional
+     - Early hardware revision; no productive documentation in this repository.
+   * - Rev02
+     - Not functional
+     - Early hardware revision; no productive documentation in this repository.
+   * - Rev03
+     - Productive
+     - First functional and documented revision. Tested up to 10 kW with an RL load.
+   * - Rev04
+     - Productive revision
+     - Adds gate-enable derived fan control, overcurrent latch/reset logic, an optical temperature PWM output, and further hardware fixes.
 
+Common Function
+===============
 
-Testing
-*******
+The board adapts the following signal groups between the Wolfspeed inverter and the UltraZohm:
 
-Tests were performed up to 10kW using an RL-load with a 14Ohm resistor and 1mH inductor
+* Three phase-current measurements and the DC-link voltage measurement are converted from single-ended inverter-side signals to fully differential RJ45 signals for the UltraZohm ADC board.
+* Six PWM gate signals are transmitted from the UltraZohm to the inverter through optical receivers.
+* Inverter-side fault and status signals are transmitted back to the UltraZohm through optical transmitters.
+* The global gate-driver disable signal is driven from the UltraZohm.
 
+General Notes
+=============
 
-.. figure:: FinalSetup.png
-
-   Integrated testing setup with RL-load
-
-Stable three-phase sinusoidal currents measured using a Rohde & Schwarz MXO 5 series oscilloscope (2GHz, 8 channels)
-
-
-.. figure:: Testgraph.png
-
-   Oscilloscope measurements of the output phase voltage at a 100kHz switching frequency with a 999V/8.33A DC-link input
-
-
-Notes for Future Revisions
-**************************
-
-A few considerations should be kept in mind for future iterations of the interface board:
-
-- **Edge connector pinning**:  
-  The HSEC8 120-pin edge card connector from Samtec uses a different numbering scheme
-  than the TI control card. Care must be taken when mapping pins to avoid interface mismatches. 
-  Details in `TI E2E Forum <https://e2e.ti.com/support/microcontrollers/arm-based-microcontrollers-group/arm-based-microcontrollers/f/arm-based-microcontrollers-forum/1486750/tmdshsecdock-edge-connector-hsec8-160-wrong-orientation-and-position-of-pin-1/>`_
-  
-
-- **Mechanical stability**:  
-  A 3D-printed support stand was added in the current design to keep the board mechanically sturdy
-  when plugged into the inverter. The step file of the stand can be found on the Bitbucket repository.
-
-.. figure:: stand.jpg
-   :width: 60%
-   :align: center
-
-   Interface board with 3D-printed stand for mechanical stability
-
-- **Software Branch**
-  We used the ``feature/wolfspeed_inverter_adapterboard`` branch of the `ultrazohm_sw <https://bitbucket.org/ultrazohm/ultrazohm_sw/src/>`_ repository to test the inverter. 
-  View the branch diff directly `here <https://bitbucket.org/ultrazohm/ultrazohm_sw/branches/compare/feature%2Fwolfspeed_inverter_adapterboard%0Ddevelop#diff>`_.
+* Check the exact PCB revision before wiring the board or using a saved FPGA/Vitis project.
+* The schematics state that the interface is for the Wolfspeed ``CRD25DA12N-FMC 25 kW inverter Rev2.0``.
+* Rev03 and Rev04 use the same basic analog measurement concept, but Rev04 changes digital behavior around gate enable, overcurrent handling, fans, and temperature feedback.
+* The Samtec HSEC8 edge-card connector numbering differs from the Texas Instruments control-card naming. Verify the schematic pinout when debugging connector-level issues.
+* The board is mechanically long when plugged into the inverter. Use the matching support concept from the hardware repository or an equivalent mechanical support.
 
 Documents and Links
-*******************
+===================
 
-- Bachelor thesis :download:`download here <Thesis_Park_BA_UltraZohm_Wolfspeed_2L_Inverter_compressed.pdf>`
-- Final presentation :download:`download here <FinalPresentation.pdf>`
-- Schematic Rev03 :download:`download here <SCH_uz_per_wolfspeed_25kw_FM3_jlc_Rev03.pdf>`
-- Poster KI-Power Symposium :download:`download here <Poster_UZandWolfspeedInterface.pptx>`
-- Altium Files `git Repo uz_per_wolfspeed_25kw_FM3 <https://bitbucket.org/ultrazohm/uz_per_wolfspeed_25kw_fm3/src/main/>`_
-- Wolfspeed 25 kW Three-Phase Inverter `CRD25DA12N-FMC <https://www.wolfspeed.com/products/power/reference-designs/crd25da12n-fmc/>`_. 
-- TI E2E `Thread on HSEC8 pinout <https://e2e.ti.com/support/microcontrollers/arm-based-microcontrollers-group/arm-based-microcontrollers/f/arm-based-microcontrollers-forum/1486750/tmdshsecdock-edge-connector-hsec8-160-wrong-orientation-and-position-of-pin-1/>`_
+* `PCB repository uz_per_wolfspeed_25kw_FM3 <https://bitbucket.org/ultrazohm/uz_per_wolfspeed_25kw_fm3/src/main/>`_
+* Wolfspeed 25 kW Three-Phase Inverter `CRD25DA12N-FMC <https://www.wolfspeed.com/products/power/reference-designs/crd25da12n-fmc/>`_
+* TI E2E `thread on HSEC8 pinout <https://e2e.ti.com/support/microcontrollers/arm-based-microcontrollers-group/arm-based-microcontrollers/f/arm-based-microcontrollers-forum/1486750/tmdshsecdock-edge-connector-hsec8-160-wrong-orientation-and-position-of-pin-1/>`_
+* Bachelor thesis :download:`download here <Thesis_Park_BA_UltraZohm_Wolfspeed_2L_Inverter_compressed.pdf>`
+* Final presentation :download:`download here <FinalPresentation.pdf>`
+* Poster KI-Power Symposium :download:`download here <Poster_UZandWolfspeedInterface.pptx>`
+
+Designer
+========
+
+Rev03 was designed by S. Park. Rev04 was designed by S. Park and M. Hoerner.


### PR DESCRIPTION
**Migrated from Bitbucket**
- Original Author: **Michael Hoerner** *(no GitHub account)*
- Original Created: July 23, 2026 at 01:54 PM UTC
- Original URL: https://bitbucket.org/ultrazohm/ultrazohm_sw/pull-requests/589

---

#### Summary: What kind of change does this PR introduce?

* Adds docs for Wolfspeed interface PCB Rev04

#### What is the current behavior?

* No docs for Rev04

#### What is the new behavior?

* Docs available

#### Does this PR introduce a breaking change?

* no

#### Which tests have to be done by reviewers before approving?

* Read the docs, commission an inverter V2.0 with it and check if you miss any information

#### Other information:

* no

#### Please check if the PR fulfills these requirements

* Build pipelines pass
* Tests for the changes have been defined
* Docs have been added/updated

‌
