### PR TITLE
Fix devcontainer Ceedling gem installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
                                                   openjdk-21-jdk \
                                                   ant
 
-RUN gem install ceedling && ln -sf /usr/local/bin/ceedling /usr/bin/ceedling
+RUN gem install ceedling --no-document && ln -sf /usr/local/bin/ceedling /usr/bin/ceedling
 
 RUN wget -O pcre-8.45.tar.gz https://github.com/pfultz2/pcre/archive/refs/tags/8.45.tar.gz \
      && echo "d6f7182602a775a7d500a0cedca6449af0400c6493951513046d17615ed0bf11  pcre-8.45.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
## Description:

This PR fixes the devcontainer build by installing Ceedling without generating Ruby documentation.
Recent Ceedling/Ruby/RDoc combinations can fail during the automatic documentation generation step of gem install ceedling, causing the devcontainer build to abort. Ceedling’s upstream installation documentation recommends using --no-document for this reason.
The installed Ceedling version remains unpinned

## Change

gem install ceedling
is changed to:
gem install ceedling --no-document

## Test
- Rebuilt the devcontainer successfully.